### PR TITLE
Verify admin status before showing admin dashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { 
   Users, DollarSign, Settings, Shield, TrendingUp, 
   Building, Plane, MapPin, CheckCircle, XCircle, 
@@ -23,6 +24,7 @@ import { supabase } from '@/integrations/supabase/client';
 const AdminDashboard = () => {
   const { user, signOut } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("overview");
   const [selectedPartner, setSelectedPartner] = useState<any>(null);
   const [isPartnerModalOpen, setIsPartnerModalOpen] = useState(false);
@@ -38,8 +40,17 @@ const AdminDashboard = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchDashboardData();
-  }, []);
+    const checkAdmin = async () => {
+      const { data: isAdmin, error } = await supabase.rpc('get_admin_status');
+      if (error || !isAdmin) {
+        navigate(user ? '/dashboard' : '/auth', { replace: true });
+        return;
+      }
+      fetchDashboardData();
+    };
+
+    checkAdmin();
+  }, [navigate, user]);
 
   const fetchDashboardData = async () => {
     try {


### PR DESCRIPTION
## Summary
- check admin status on admin dashboard mount and redirect non-admins

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68a6c3833c7c8324bcfe451754a65df5