### PR TITLE
Fix admin auth redirect paths

### DIFF
--- a/src/pages/AdminAuth.tsx
+++ b/src/pages/AdminAuth.tsx
@@ -12,7 +12,7 @@ const AdminAuth = () => {
   const location = useLocation();
 
   // Get the intended destination after login
-  const from = location.state?.from?.pathname || '/admin-dashboard';
+  const from = location.state?.from?.pathname || '/admin/dashboard';
 
   // Check if current user is admin
   useEffect(() => {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -169,7 +169,7 @@ const AdminDashboard = () => {
   };
 
   return (
-    <AuthGuard redirectTo="/admin-auth">
+    <AuthGuard redirectTo="/admin/auth">
       <div className="min-h-screen bg-background">
         <Navbar />
         


### PR DESCRIPTION
## Summary
- use /admin/dashboard as fallback redirect for admin auth
- adjust admin dashboard auth guard to redirect to /admin/auth

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors in supabase functions and config)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c39e33108324bc0cbd9552e2ed01