### PR TITLE
Add tests for booking enhancement components

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -78,6 +79,7 @@
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
+    "@testing-library/dom": "^10.4.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -88,6 +90,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
-  }
+    "vite": "^5.4.19",
+    "jsdom": "^24.0.0"
+  },
+  "packageManager": "npm@10.2.0"
 }

--- a/src/features/bookingEnhancements/components/__tests__/FavoritesSidebar.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/FavoritesSidebar.test.tsx
@@ -1,0 +1,45 @@
+import { render, waitFor } from '@testing-library/react';
+import FavoritesSidebar from '../FavoritesSidebar';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user1' } })
+}));
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast })
+}));
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  fetchUserFavorites: vi.fn()
+}));
+
+import { fetchUserFavorites } from '@/lib/bookingDataClient';
+
+describe('FavoritesSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads favorites on mount', async () => {
+    (fetchUserFavorites as any).mockResolvedValue([]);
+
+    render(<FavoritesSidebar />);
+
+    await waitFor(() => {
+      expect(fetchUserFavorites).toHaveBeenCalled();
+    });
+  });
+
+  it('shows error toast on failure', async () => {
+    (fetchUserFavorites as any).mockRejectedValue(new Error('fail'));
+
+    render(<FavoritesSidebar />);
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/bookingEnhancements/components/__tests__/LocalTipsPanel.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/LocalTipsPanel.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import LocalTipsPanel from '../LocalTipsPanel';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  fetchLocalInsights: vi.fn()
+}));
+
+import { fetchLocalInsights } from '@/lib/bookingDataClient';
+
+describe('LocalTipsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches insights on success', async () => {
+    (fetchLocalInsights as any).mockResolvedValue([{ id: '1', tip_type: 'dining', content: 'Tip' }]);
+
+    render(<LocalTipsPanel locationId="LOC" />);
+
+    await waitFor(() => {
+      expect(fetchLocalInsights).toHaveBeenCalledWith('LOC');
+    });
+  });
+
+  it('handles fetch failure gracefully', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (fetchLocalInsights as any).mockRejectedValue(new Error('fail'));
+
+    render(<LocalTipsPanel locationId="LOC" />);
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled();
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/src/features/bookingEnhancements/components/__tests__/OffersWidget.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/OffersWidget.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import OffersWidget from '../OffersWidget';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  listDynamicOffers: vi.fn()
+}));
+
+import { listDynamicOffers } from '@/lib/bookingDataClient';
+
+describe('OffersWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders offers on success', async () => {
+    (listDynamicOffers as any).mockResolvedValue([
+      { id: '1', route: 'SYD-MEL', discount_pct: 20, offer_type: 'flash_sale', description: 'deal', valid_until: new Date().toISOString() }
+    ]);
+
+    render(<OffersWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/20% OFF/)).toBeInTheDocument();
+    });
+  });
+
+  it('logs error on failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (listDynamicOffers as any).mockRejectedValue(new Error('fail'));
+
+    render(<OffersWidget />);
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled();
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/src/features/bookingEnhancements/components/__tests__/OneClickBooking.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/OneClickBooking.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import OneClickBooking from '../OneClickBooking';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user1' } })
+}));
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast })
+}));
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  fetchUserPreferences: vi.fn(),
+  saveUserPreferences: vi.fn(),
+  fetchPassportInfo: vi.fn(),
+  fetchPaymentMethods: vi.fn()
+}));
+
+import { fetchUserPreferences, fetchPassportInfo, fetchPaymentMethods } from '@/lib/bookingDataClient';
+
+describe('OneClickBooking', () => {
+  const bookingData = { destination: 'NYC', checkIn: '2024-01-01', checkOut: '2024-01-02', guests: 1 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enables one-click booking when requirements met', async () => {
+    (fetchUserPreferences as any).mockResolvedValue({ room_type: 'standard' });
+    (fetchPassportInfo as any).mockResolvedValue({ verified: true });
+    (fetchPaymentMethods as any).mockResolvedValue([{ id: 'pm1', is_default: true }]);
+
+    render(<OneClickBooking bookingData={bookingData} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/One-Click Book Now/)).toBeInTheDocument();
+    });
+  });
+
+  it('falls back when data fetch fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (fetchUserPreferences as any).mockResolvedValue({});
+    (fetchPassportInfo as any).mockRejectedValue(new Error('fail'));
+    (fetchPaymentMethods as any).mockResolvedValue([]);
+
+    render(<OneClickBooking bookingData={bookingData} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Continue with Full Booking/)).toBeInTheDocument();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/src/features/bookingEnhancements/components/__tests__/PassportUploader.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/PassportUploader.test.tsx
@@ -1,0 +1,57 @@
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import PassportUploader from '../PassportUploader';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user1' } })
+}));
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast })
+}));
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  savePassportInfo: vi.fn()
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { functions: { invoke: vi.fn() } }
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+
+describe('PassportUploader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('validates passport successfully', async () => {
+    (supabase.functions.invoke as any).mockResolvedValue({ data: { success: true, verified: true, extractedData: {} } });
+
+    const { container } = render(<PassportUploader />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['dummy'], 'passport.jpg', { type: 'image/jpeg' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Upload successful' }));
+    });
+  });
+
+  it('shows error on validation failure', async () => {
+    (supabase.functions.invoke as any).mockRejectedValue(new Error('fail'));
+
+    const { container } = render(<PassportUploader />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['dummy'], 'passport.jpg', { type: 'image/jpeg' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Validation error' }));
+    });
+  });
+});

--- a/src/features/bookingEnhancements/components/__tests__/PaymentVault.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/PaymentVault.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import PaymentVault from '../PaymentVault';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user1' } })
+}));
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast })
+}));
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  fetchPaymentMethods: vi.fn()
+}));
+
+import { fetchPaymentMethods } from '@/lib/bookingDataClient';
+
+describe('PaymentVault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders payment methods on success', async () => {
+    (fetchPaymentMethods as any).mockResolvedValue([
+      { id: '1', provider: 'visa', type: 'card', is_default: true }
+    ]);
+
+    render(<PaymentVault />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/visa/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error toast on failure', async () => {
+    (fetchPaymentMethods as any).mockRejectedValue(new Error('fail'));
+
+    render(<PaymentVault />);
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/bookingEnhancements/components/__tests__/UserPreferencesForm.test.tsx
+++ b/src/features/bookingEnhancements/components/__tests__/UserPreferencesForm.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import UserPreferencesForm from '../UserPreferencesForm';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user1' } })
+}));
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast })
+}));
+
+vi.mock('@/lib/bookingDataClient', () => ({
+  fetchUserPreferences: vi.fn(),
+  saveUserPreferences: vi.fn()
+}));
+
+import { fetchUserPreferences, saveUserPreferences } from '@/lib/bookingDataClient';
+
+describe('UserPreferencesForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads preferences and saves successfully', async () => {
+    (fetchUserPreferences as any).mockResolvedValue(null);
+    (saveUserPreferences as any).mockResolvedValue({});
+
+    render(<UserPreferencesForm />);
+
+    fireEvent.click(await screen.findByText('Save Preferences'));
+
+    await waitFor(() => {
+      expect(saveUserPreferences).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
+    });
+  });
+
+  it('shows error toast on save failure', async () => {
+    (fetchUserPreferences as any).mockResolvedValue(null);
+    (saveUserPreferences as any).mockRejectedValue(new Error('fail'));
+
+    render(<UserPreferencesForm />);
+
+    fireEvent.click(await screen.findByText('Save Preferences'));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,9 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.ts',
+  },
 }));


### PR DESCRIPTION
## Summary
- add vitest/@testing-library tests for booking enhancement components with mocked Supabase
- configure vitest and npm test script
- run tests in CI via GitHub workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fb17bfd48324938e7b869e2afeff