### PR TITLE
Add travel tech intelligence widgets to home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,24 +9,23 @@ import ChatWidget from "@/features/makuBot/components/ChatWidget";
 import AgenticWidget from "@/features/agenticBot/components/AgenticWidget";
 import { SocialProofIndicators } from "@/components/ota/SocialProofIndicators";
 import { PriceIntelligence } from "@/components/ota/PriceIntelligence";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Zap, Activity, TrendingUp } from "lucide-react";
 const Index = () => {
-  return <div className="min-h-screen bg-background">
+  return (
+    <div className="min-h-screen bg-background">
       <Navbar />
       <HeroSection />
       <MarketplacePills />
-      
-      {/* Travel Tech Intelligence Section */}
-      
-      
+
+      <SocialProofIndicators itemType="landing" itemId="index" />
+      <PriceIntelligence itemType="landing" itemId="index" currentPrice={0} />
+
       <SearchSection />
       <MarketplaceSection />
       <FeaturedListings />
       <Footer />
       <ChatWidget userVertical="Solo" />
       <AgenticWidget />
-    </div>;
+    </div>
+  );
 };
 export default Index;


### PR DESCRIPTION
## Summary
- Integrate SocialProofIndicators and PriceIntelligence widgets on the index page
- Remove placeholder comment for Travel Tech Intelligence section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a6fadb667c832493182ad1bc44c9ac