### PR TITLE
feat: add shared pino logger for supabase functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "leaflet": "^1.9.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
+        "pino": "^9.9.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -71,6 +72,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@testing-library/dom": "^10.4.0",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -80,6 +82,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^15.15.0",
+        "jsdom": "^24.0.0",
         "lovable-tagger": "^1.1.8",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
@@ -98,13 +101,40 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -118,10 +148,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-      "dev": true,
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -164,6 +193,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -839,7 +983,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -857,7 +1000,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -872,7 +1014,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -882,7 +1023,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -898,7 +1038,6 @@
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -909,7 +1048,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -923,7 +1061,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -933,7 +1070,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -947,7 +1083,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2922,6 +3057,40 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.4.tgz",
@@ -2968,6 +3137,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3094,14 +3269,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3112,7 +3287,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3530,6 +3705,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3551,7 +3736,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3564,7 +3748,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3580,14 +3763,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3597,11 +3778,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3639,6 +3831,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -3683,14 +3891,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3714,7 +3920,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3765,6 +3970,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3779,7 +3998,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3852,7 +4070,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3877,7 +4094,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3932,7 +4148,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3945,14 +4160,25 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3975,7 +4201,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3995,7 +4220,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4003,6 +4227,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -4131,6 +4376,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -4158,6 +4454,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -4180,6 +4483,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -4190,14 +4512,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -4216,11 +4536,25 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -4262,14 +4596,75 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4554,7 +4949,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4571,7 +4965,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4594,11 +4987,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4635,7 +5036,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4686,7 +5086,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -4697,6 +5096,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4731,8 +5147,32 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4746,11 +5186,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4771,7 +5224,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4784,7 +5236,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4794,7 +5245,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4819,6 +5269,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4836,17 +5299,99 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -4939,7 +5484,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4952,7 +5496,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4968,7 +5511,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4978,7 +5520,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4988,7 +5529,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5001,17 +5541,22 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isows": {
@@ -5033,7 +5578,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -5049,7 +5593,6 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -5072,6 +5615,84 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/json-buffer": {
@@ -5135,7 +5756,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5148,7 +5768,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -5664,7 +6283,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -5673,6 +6291,15 @@
       "integrity": "sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5684,11 +6311,20 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5698,7 +6334,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5706,6 +6341,41 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -5734,7 +6404,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5750,7 +6419,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -5804,7 +6472,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5820,6 +6487,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+      "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5833,10 +6507,18 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/optionator": {
@@ -5893,7 +6575,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -5907,6 +6588,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5923,7 +6617,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5933,14 +6626,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -5975,13 +6666,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5991,17 +6681,52 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.0.tgz",
+      "integrity": "sha512-zxsRIQG9HzG+jEljmvmZupOMDUQ0Jpj0yAgE28jQvvrdYTlEaiGwelJpdndMl/MBuRr70heIj83QyqJUWaU8mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6039,7 +6764,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6057,7 +6781,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -6077,7 +6800,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6113,7 +6835,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6139,7 +6860,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6153,7 +6873,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6165,6 +6884,63 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6183,21 +6959,40 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6212,6 +7007,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/react": {
@@ -6452,7 +7253,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6462,13 +7262,33 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/recharts": {
@@ -6516,11 +7336,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -6548,7 +7374,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6590,11 +7415,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6612,6 +7443,35 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -6640,7 +7500,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6653,7 +7512,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6669,13 +7527,21 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/sonner": {
@@ -6697,6 +7563,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6713,7 +7588,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -6732,7 +7606,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6747,7 +7620,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6757,14 +7629,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6777,7 +7647,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6794,7 +7663,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6807,7 +7675,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6860,7 +7727,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -6896,7 +7762,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6904,6 +7769,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
@@ -6919,7 +7791,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -6966,7 +7837,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -6976,13 +7846,21 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -7019,18 +7897,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -7062,13 +7928,28 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -7094,7 +7975,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -7160,6 +8040,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -7199,6 +8089,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -7257,7 +8158,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vaul": {
@@ -7448,16 +8348,17 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/webidl-conversions": {
@@ -7465,6 +8366,29 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -7480,7 +8404,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7522,7 +8445,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -7541,7 +8463,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7559,7 +8480,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7569,14 +8489,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7591,7 +8509,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7604,7 +8521,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7634,11 +8550,27 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/yaml": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
+    "pino": "^9.9.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -75,23 +76,23 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/dom": "^10.4.0",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
-    "@testing-library/dom": "^10.4.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^15.15.0",
+    "jsdom": "^24.0.0",
     "lovable-tagger": "^1.1.8",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19",
-    "jsdom": "^24.0.0"
+    "vite": "^5.4.19"
   },
   "packageManager": "npm@10.2.0"
 }

--- a/supabase/functions/_shared/logger.ts
+++ b/supabase/functions/_shared/logger.ts
@@ -1,0 +1,7 @@
+import pino from 'npm:pino';
+
+const logger = pino({
+  level: Deno.env.get('LOG_LEVEL') ?? (Deno.env.get('NODE_ENV') === 'production' ? 'info' : 'debug'),
+});
+
+export default logger;

--- a/supabase/functions/activity-search/index.ts
+++ b/supabase/functions/activity-search/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,7 +15,7 @@ serve(async (req) => {
   try {
     const { destination, date, participants } = await req.json();
 
-    console.log('Activity search request:', {
+    logger.info('Activity search request:', {
       destination,
       date,
       participants
@@ -142,7 +143,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Activity search error:', error);
+    logger.error('Activity search error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-car-search/index.ts
+++ b/supabase/functions/amadeus-car-search/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -79,7 +80,7 @@ const searchCars = async (params: CarSearchParams, accessToken: string) => {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus car search error:', errorText);
+    logger.error('Amadeus car search error:', errorText);
     throw new Error(`Car search failed: ${response.statusText}`);
   }
 
@@ -94,7 +95,7 @@ serve(async (req) => {
   try {
     const searchParams: CarSearchParams = await req.json();
     
-    console.log('Searching cars with Amadeus:', searchParams);
+    logger.info('Searching cars with Amadeus:', searchParams);
 
     // Get Amadeus access token
     const accessToken = await getAmadeusAccessToken();
@@ -102,7 +103,7 @@ serve(async (req) => {
     // Search for cars
     const carResults = await searchCars(searchParams, accessToken);
     
-    console.log('Car search successful:', carResults.data?.length || 0, 'offers found');
+    logger.info('Car search successful:', carResults.data?.length || 0, 'offers found');
 
     // Transform the response to our format
     const cars = carResults.data?.map((offer: any) => ({
@@ -162,7 +163,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Car search error:', error);
+    logger.error('Car search error:', error);
     
     return new Response(JSON.stringify({
       success: false,

--- a/supabase/functions/amadeus-flight-booking/index.ts
+++ b/supabase/functions/amadeus-flight-booking/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -122,7 +123,7 @@ const createFlightOrder = async (params: FlightBookingParams, accessToken: strin
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus booking error:', errorText);
+    logger.error('Amadeus booking error:', errorText);
     throw new Error(`Flight booking failed: ${response.statusText} - ${errorText}`);
   }
 
@@ -137,7 +138,7 @@ serve(async (req) => {
   try {
     const bookingParams: FlightBookingParams = await req.json();
     
-    console.log('Creating flight booking with Amadeus:', {
+    logger.info('Creating flight booking with Amadeus:', {
       flightOffersCount: bookingParams.flightOffers?.length,
       passengersCount: bookingParams.passengers?.length
     });
@@ -148,7 +149,7 @@ serve(async (req) => {
     // Create flight order
     const flightOrder = await createFlightOrder(bookingParams, accessToken);
     
-    console.log('Flight booking successful:', flightOrder.data?.id);
+    logger.info('Flight booking successful:', flightOrder.data?.id);
 
     // Transform the response to our format
     const booking = {
@@ -174,7 +175,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Flight booking error:', error);
+    logger.error('Flight booking error:', error);
     
     return new Response(JSON.stringify({
       success: false,

--- a/supabase/functions/amadeus-flight-inspiration/index.ts
+++ b/supabase/functions/amadeus-flight-inspiration/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -63,7 +64,7 @@ async function getMostTraveledDestinations(accessToken: string, originLocationCo
     );
 
     if (!response.ok) {
-      console.log(`Most traveled destinations API failed: ${response.statusText}`);
+      logger.info(`Most traveled destinations API failed: ${response.statusText}`);
       return [];
     }
 
@@ -75,7 +76,7 @@ async function getMostTraveledDestinations(accessToken: string, originLocationCo
       departure: originLocationCode,
     })) || [];
   } catch (error) {
-    console.error('Error fetching most traveled destinations:', error);
+    logger.error('Error fetching most traveled destinations:', error);
     return [];
   }
 }
@@ -95,7 +96,7 @@ async function getFlightInspiration(accessToken: string, origin: string = 'SYD')
     );
 
     if (!response.ok) {
-      console.log(`Flight inspiration API failed: ${response.statusText}`);
+      logger.info(`Flight inspiration API failed: ${response.statusText}`);
       return [];
     }
 
@@ -113,7 +114,7 @@ async function getFlightInspiration(accessToken: string, origin: string = 'SYD')
       returnDate: item.returnDate,
     })) || [];
   } catch (error) {
-    console.error('Error fetching flight inspiration:', error);
+    logger.error('Error fetching flight inspiration:', error);
     return [];
   }
 }
@@ -155,7 +156,7 @@ serve(async (req) => {
     const origin = searchParams.get('origin') || 'SYD';
     const type = searchParams.get('type') || 'inspiration'; // 'inspiration', 'popular', 'both'
 
-    console.log(`Fetching flight inspiration data for origin: ${origin}, type: ${type}`);
+    logger.info(`Fetching flight inspiration data for origin: ${origin}, type: ${type}`);
 
     const accessToken = await getAmadeusAccessToken();
     
@@ -167,7 +168,7 @@ serve(async (req) => {
       
       // Fallback to mock data if API fails
       if (inspirationData.length === 0) {
-        console.log('Using mock inspiration data as fallback');
+        logger.info('Using mock inspiration data as fallback');
         inspirationData = generateMockInspirationData();
       }
     }
@@ -191,7 +192,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Error in flight inspiration function:', error);
+    logger.error('Error in flight inspiration function:', error);
     
     // Return mock data as fallback
     const mockData = generateMockInspirationData();

--- a/supabase/functions/amadeus-flight-offers/index.ts
+++ b/supabase/functions/amadeus-flight-offers/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -111,7 +112,7 @@ serve(async (req) => {
     );
 
     const params: FlightSearchParams = await req.json();
-    console.log('[FLIGHT-OFFERS] Search params:', params);
+    logger.info('[FLIGHT-OFFERS] Search params:', params);
 
     const searchKey = generateSearchKey(params);
     
@@ -124,7 +125,7 @@ serve(async (req) => {
       .single();
 
     if (cached && !cacheError) {
-      console.log('[FLIGHT-OFFERS] Cache hit');
+      logger.info('[FLIGHT-OFFERS] Cache hit');
       return new Response(JSON.stringify({
         success: true,
         data: cached.offers,
@@ -135,7 +136,7 @@ serve(async (req) => {
     }
 
     // Cache miss - call Amadeus
-    console.log('[FLIGHT-OFFERS] Cache miss, calling Amadeus');
+    logger.info('[FLIGHT-OFFERS] Cache miss, calling Amadeus');
     const accessToken = await getAmadeusAccessToken();
     const amadeusData = await searchFlightOffers(params, accessToken);
 
@@ -156,7 +157,7 @@ serve(async (req) => {
       p_ttl: ttlExpires.toISOString()
     });
 
-    console.log('[FLIGHT-OFFERS] Search completed, offers:', amadeusData.data?.length || 0);
+    logger.info('[FLIGHT-OFFERS] Search completed, offers:', amadeusData.data?.length || 0);
 
     return new Response(JSON.stringify({
       success: true,
@@ -167,7 +168,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('[FLIGHT-OFFERS] Error:', error);
+    logger.error('[FLIGHT-OFFERS] Error:', error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message

--- a/supabase/functions/amadeus-flight-price-confirm/index.ts
+++ b/supabase/functions/amadeus-flight-price-confirm/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -52,7 +53,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 async function confirmFlightPrice(params: FlightPriceParams, accessToken: string) {
   const url = 'https://test.api.amadeus.com/v1/shopping/flight-offers/pricing';
   
-  console.log('Confirming flight price for offer ID:', params.flightOfferId);
+  logger.info('Confirming flight price for offer ID:', params.flightOfferId);
   
   const body = {
     data: {
@@ -80,12 +81,12 @@ async function confirmFlightPrice(params: FlightPriceParams, accessToken: string
   });
 
   if (!response.ok) {
-    console.error('Flight price confirmation API error:', response.status, response.statusText);
+    logger.error('Flight price confirmation API error:', response.status, response.statusText);
     throw new Error(`Flight price confirmation API error: ${response.statusText}`);
   }
 
   const data = await response.json();
-  console.log('Flight price confirmation response:', data);
+  logger.info('Flight price confirmation response:', data);
   return data;
 }
 
@@ -105,11 +106,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Flight price confirmation request for offer:', flightOfferId);
+    logger.info('Flight price confirmation request for offer:', flightOfferId);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for flight price confirmation');
+    logger.info('Got Amadeus access token for flight price confirmation');
 
     // Confirm flight price
     const priceData = await confirmFlightPrice({ flightOfferId, pricingOptions }, accessToken);
@@ -136,7 +137,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Flight price confirmation function error:', error);
+    logger.error('Flight price confirmation function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-flight-search/index.ts
+++ b/supabase/functions/amadeus-flight-search/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -112,7 +113,7 @@ serve(async (req) => {
       nonStop = false
     } = await req.json();
 
-    console.log('Amadeus flight search:', { origin, destination, departureDate, returnDate, passengers });
+    logger.info('Amadeus flight search:', { origin, destination, departureDate, returnDate, passengers });
 
     // Get Amadeus access token
     const accessToken = await getAmadeusAccessToken();
@@ -290,7 +291,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Amadeus flight search error:', error);
+    logger.error('Amadeus flight search error:', error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message,

--- a/supabase/functions/amadeus-health/index.ts
+++ b/supabase/functions/amadeus-health/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/amadeus-hotel-autocomplete/index.ts
+++ b/supabase/functions/amadeus-hotel-autocomplete/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -43,7 +44,7 @@ async function getHotelAutocomplete(query: string, accessToken: string) {
   // Use correct Amadeus Hotel List API endpoint - no "by-keyword" suffix
   const url = `https://test.api.amadeus.com/v1/reference-data/locations/hotels?keyword=${encodeURIComponent(query)}&subType=HOTEL_LEISURE,HOTEL_GDS`;
   
-  console.log('Getting hotel autocomplete for:', query, 'using URL:', url);
+  logger.info('Getting hotel autocomplete for:', query, 'using URL:', url);
   
   const response = await fetch(url, {
     headers: {
@@ -54,7 +55,7 @@ async function getHotelAutocomplete(query: string, accessToken: string) {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Hotel autocomplete API error:', response.status, response.statusText, errorText);
+    logger.error('Hotel autocomplete API error:', response.status, response.statusText, errorText);
     
     // Handle rate limiting with exponential backoff
     if (response.status === 429) {
@@ -65,7 +66,7 @@ async function getHotelAutocomplete(query: string, accessToken: string) {
   }
 
   const data = await response.json();
-  console.log('Hotel autocomplete response:', data);
+  logger.info('Hotel autocomplete response:', data);
   return data;
 }
 
@@ -85,11 +86,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Hotel autocomplete request for:', query);
+    logger.info('Hotel autocomplete request for:', query);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for hotel autocomplete');
+    logger.info('Got Amadeus access token for hotel autocomplete');
 
     // Get hotel suggestions
     const autocompleteData = await getHotelAutocomplete(query, accessToken);
@@ -126,7 +127,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Hotel autocomplete function error:', error);
+    logger.error('Hotel autocomplete function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-hotel-booking/index.ts
+++ b/supabase/functions/amadeus-hotel-booking/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -58,7 +59,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 }
 
 async function bookHotel(params: HotelBookingParams, accessToken: string): Promise<any> {
-  console.log('Creating Amadeus hotel booking:', {
+  logger.info('Creating Amadeus hotel booking:', {
     offerId: params.hotelOfferId,
     guest: `${params.guestDetails.firstName} ${params.guestDetails.lastName}`,
     email: params.guestDetails.email,
@@ -100,7 +101,7 @@ async function bookHotel(params: HotelBookingParams, accessToken: string): Promi
     }
   };
 
-  console.log('Amadeus booking request:', JSON.stringify(bookingData, null, 2));
+  logger.info('Amadeus booking request:', JSON.stringify(bookingData, null, 2));
 
   const response = await fetch('https://test.api.amadeus.com/v1/booking/hotel-bookings', {
     method: 'POST',
@@ -113,7 +114,7 @@ async function bookHotel(params: HotelBookingParams, accessToken: string): Promi
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus hotel booking failed:', {
+    logger.error('Amadeus hotel booking failed:', {
       status: response.status,
       statusText: response.statusText,
       error: errorText
@@ -122,7 +123,7 @@ async function bookHotel(params: HotelBookingParams, accessToken: string): Promi
   }
 
   const result = await response.json();
-  console.log('Amadeus booking successful:', {
+  logger.info('Amadeus booking successful:', {
     bookingId: result.data?.[0]?.id,
     confirmationNumber: result.data?.[0]?.bookingReference,
     status: result.data?.[0]?.status
@@ -189,7 +190,7 @@ serve(async (req) => {
       }
     );
   } catch (error) {
-    console.error('Hotel booking error:', error);
+    logger.error('Hotel booking error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-hotel-details/index.ts
+++ b/supabase/functions/amadeus-hotel-details/index.ts
@@ -1,4 +1,5 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -63,7 +64,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    console.log('Fetching hotel details for:', { hotelId, checkIn, checkOut, adults, children, rooms });
+    logger.info('Fetching hotel details for:', { hotelId, checkIn, checkOut, adults, children, rooms });
 
     // Get Amadeus access token
     const accessToken = await getAmadeusAccessToken();
@@ -88,7 +89,7 @@ Deno.serve(async (req) => {
     url.searchParams.set('includeClosed', 'false');
     url.searchParams.set('lang', 'en');
 
-    console.log('Making request to Amadeus:', url.toString());
+    logger.info('Making request to Amadeus:', url.toString());
 
     // Make request to Amadeus
     const response = await fetch(url.toString(), {
@@ -102,7 +103,7 @@ Deno.serve(async (req) => {
     const responseData = await response.json();
 
     if (!response.ok) {
-      console.error('Amadeus API error:', response.status, responseData);
+      logger.error('Amadeus API error:', response.status, responseData);
       return new Response(
         JSON.stringify({ 
           success: false, 
@@ -116,8 +117,8 @@ Deno.serve(async (req) => {
       );
     }
 
-    console.log(`✅ Successfully fetched hotel details for hotel ${hotelId}`);
-    console.log(`Found ${responseData.data?.length || 0} hotel(s) with offers`);
+    logger.info(`✅ Successfully fetched hotel details for hotel ${hotelId}`);
+    logger.info(`Found ${responseData.data?.length || 0} hotel(s) with offers`);
 
     return new Response(
       JSON.stringify({ 
@@ -133,7 +134,7 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Hotel details error:', error);
+    logger.error('Hotel details error:', error);
     return new Response(
       JSON.stringify({ 
         success: false, 

--- a/supabase/functions/amadeus-hotel-list/index.ts
+++ b/supabase/functions/amadeus-hotel-list/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -33,7 +34,7 @@ const getAmadeusAccessToken = async (): Promise<string> => {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus auth failed:', errorText);
+    logger.error('Amadeus auth failed:', errorText);
     throw new Error(`Amadeus auth failed: ${response.statusText}`);
   }
 
@@ -55,7 +56,7 @@ const getHotelList = async (params: any, accessToken: string) => {
   if (params.amenities) searchParams.append('amenities', params.amenities);
   if (params.ratings) searchParams.append('ratings', params.ratings);
 
-  console.log('Amadeus Hotel List API call:', `https://test.api.amadeus.com/v1/reference-data/locations/hotels/by-city?${searchParams}`);
+  logger.info('Amadeus Hotel List API call:', `https://test.api.amadeus.com/v1/reference-data/locations/hotels/by-city?${searchParams}`);
 
   const response = await fetch(
     `https://test.api.amadeus.com/v1/reference-data/locations/hotels/by-city?${searchParams}`,
@@ -69,7 +70,7 @@ const getHotelList = async (params: any, accessToken: string) => {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus hotel list error:', {
+    logger.error('Amadeus hotel list error:', {
       status: response.status,
       statusText: response.statusText,
       error: errorText,
@@ -79,7 +80,7 @@ const getHotelList = async (params: any, accessToken: string) => {
   }
 
   const result = await response.json();
-  console.log('Amadeus Hotel List API response:', {
+  logger.info('Amadeus Hotel List API response:', {
     dataCount: result.data?.length || 0,
     meta: result.meta
   });
@@ -104,7 +105,7 @@ serve(async (req) => {
       ratings
     } = await req.json();
 
-    console.log('=== Amadeus Hotel List Request ===', {
+    logger.info('=== Amadeus Hotel List Request ===', {
       cityCode,
       latitude,
       longitude,
@@ -150,7 +151,7 @@ serve(async (req) => {
       lastUpdate: hotel.lastUpdate
     })) || [];
 
-    console.log(`=== Hotel List Complete ===`, {
+    logger.info(`=== Hotel List Complete ===`, {
       hotelsFound: transformedHotels.length,
       searchSuccess: true
     });
@@ -170,7 +171,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('=== Amadeus Hotel List Error ===', {
+    logger.error('=== Amadeus Hotel List Error ===', {
       error: error.message,
       stack: error.stack,
       timestamp: new Date().toISOString()

--- a/supabase/functions/amadeus-hotel-offers/index.ts
+++ b/supabase/functions/amadeus-hotel-offers/index.ts
@@ -34,7 +34,7 @@ const getAmadeusAccessToken = async (): Promise<string> => {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus auth failed:', errorText);
+    logger.error('Amadeus auth failed:', errorText);
     throw new Error(`Amadeus auth failed: ${response.statusText}`);
   }
 
@@ -67,7 +67,7 @@ const getHotelOffers = async (
   }
 
   const url = `https://test.api.amadeus.com/v3/shopping/hotel-offers?${params.toString()}`;
-  console.log('Amadeus Hotel Offers API call:', url);
+  logger.info('Amadeus Hotel Offers API call:', url);
 
   const response = await fetch(url, {
     headers: {
@@ -78,7 +78,7 @@ const getHotelOffers = async (
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus hotel offers error:', {
+    logger.error('Amadeus hotel offers error:', {
       status: response.status,
       statusText: response.statusText,
       error: errorText,
@@ -88,7 +88,7 @@ const getHotelOffers = async (
   }
 
   const result = await response.json();
-  console.log('Amadeus Hotel Offers API response:', {
+  logger.info('Amadeus Hotel Offers API response:', {
     dataExists: !!result.data,
     dataLength: result.data?.length || 0,
     hotelExists: !!result.data?.[0]?.hotel,
@@ -108,7 +108,7 @@ serve(async (req) => {
   try {
     const { hotelId, checkIn, checkOut, adults = 2, children = 0, rooms = 1, currency = 'USD' } = await req.json();
 
-    console.log('=== Amadeus Hotel Offers Request ===', {
+    logger.info('=== Amadeus Hotel Offers Request ===', {
       hotelId,
       checkIn,
       checkOut,
@@ -142,7 +142,7 @@ serve(async (req) => {
 
     // Check if hotel was found
     if (!hotel) {
-      console.log('=== Hotel Not Found ===', {
+      logger.info('=== Hotel Not Found ===', {
         hotelId,
         responseStructure: Object.keys(offersData),
         dataExists: !!offersData.data,
@@ -203,7 +203,7 @@ serve(async (req) => {
       self: offer.self
     }));
 
-    console.log(`=== Hotel Offers Complete ===`, {
+    logger.info(`=== Hotel Offers Complete ===`, {
       hotelId: hotel?.hotelId,
       hotelName: hotel?.name,
       offersFound: transformedOffers.length,
@@ -234,7 +234,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('=== Amadeus Hotel Offers Error ===', {
+    logger.error('=== Amadeus Hotel Offers Error ===', {
       error: error.message,
       stack: error.stack,
       timestamp: new Date().toISOString()

--- a/supabase/functions/amadeus-hotel-photos/index.ts
+++ b/supabase/functions/amadeus-hotel-photos/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -42,7 +43,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 async function getHotelPhotos(hotelId: string, accessToken: string) {
   const url = `https://test.api.amadeus.com/v2/media/files/generated-photos?category=HOTEL&hotelIds=${hotelId}`;
   
-  console.log('Getting hotel photos for:', hotelId);
+  logger.info('Getting hotel photos for:', hotelId);
   
   const response = await fetch(url, {
     headers: {
@@ -52,12 +53,12 @@ async function getHotelPhotos(hotelId: string, accessToken: string) {
   });
 
   if (!response.ok) {
-    console.error('Hotel photos API error:', response.status, response.statusText);
+    logger.error('Hotel photos API error:', response.status, response.statusText);
     throw new Error(`Hotel photos API error: ${response.statusText}`);
   }
 
   const data = await response.json();
-  console.log('Hotel photos response:', data);
+  logger.info('Hotel photos response:', data);
   return data;
 }
 
@@ -77,11 +78,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Hotel photos request for:', hotelId);
+    logger.info('Hotel photos request for:', hotelId);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for hotel photos');
+    logger.info('Got Amadeus access token for hotel photos');
 
     // Get hotel photos
     const photosData = await getHotelPhotos(hotelId, accessToken);
@@ -108,7 +109,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Hotel photos function error:', error);
+    logger.error('Hotel photos function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-hotel-ratings/index.ts
+++ b/supabase/functions/amadeus-hotel-ratings/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -42,7 +43,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 async function getHotelRatings(hotelIds: string[], accessToken: string) {
   const url = 'https://test.api.amadeus.com/v2/e-reputation/hotel-sentiments';
   
-  console.log('Getting hotel ratings for hotels:', hotelIds);
+  logger.info('Getting hotel ratings for hotels:', hotelIds);
   
   const response = await fetch(url, {
     method: 'POST',
@@ -59,12 +60,12 @@ async function getHotelRatings(hotelIds: string[], accessToken: string) {
   });
 
   if (!response.ok) {
-    console.error('Hotel ratings API error:', response.status, response.statusText);
+    logger.error('Hotel ratings API error:', response.status, response.statusText);
     throw new Error(`Hotel ratings API error: ${response.statusText}`);
   }
 
   const data = await response.json();
-  console.log('Hotel ratings response:', data);
+  logger.info('Hotel ratings response:', data);
   return data;
 }
 
@@ -84,11 +85,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Hotel ratings request for hotels:', hotelIds);
+    logger.info('Hotel ratings request for hotels:', hotelIds);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for hotel ratings');
+    logger.info('Got Amadeus access token for hotel ratings');
 
     // Get hotel ratings
     const ratingsData = await getHotelRatings(hotelIds, accessToken);
@@ -126,7 +127,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Hotel ratings function error:', error);
+    logger.error('Hotel ratings function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-points-of-interest/index.ts
+++ b/supabase/functions/amadeus-points-of-interest/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -42,7 +43,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 async function getPointsOfInterest(latitude: number, longitude: number, radius: number, accessToken: string) {
   const url = `https://test.api.amadeus.com/v1/reference-data/locations/pois?latitude=${latitude}&longitude=${longitude}&radius=${radius}`;
   
-  console.log('Getting points of interest for coordinates:', latitude, longitude, 'radius:', radius);
+  logger.info('Getting points of interest for coordinates:', latitude, longitude, 'radius:', radius);
   
   const response = await fetch(url, {
     headers: {
@@ -52,12 +53,12 @@ async function getPointsOfInterest(latitude: number, longitude: number, radius: 
   });
 
   if (!response.ok) {
-    console.error('Points of Interest API error:', response.status, response.statusText);
+    logger.error('Points of Interest API error:', response.status, response.statusText);
     throw new Error(`Points of Interest API error: ${response.statusText}`);
   }
 
   const data = await response.json();
-  console.log('Points of Interest response:', data);
+  logger.info('Points of Interest response:', data);
   return data;
 }
 
@@ -77,11 +78,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Points of interest request for coordinates:', latitude, longitude);
+    logger.info('Points of interest request for coordinates:', latitude, longitude);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for points of interest');
+    logger.info('Got Amadeus access token for points of interest');
 
     // Get points of interest
     const poisData = await getPointsOfInterest(parseFloat(latitude), parseFloat(longitude), radius, accessToken);
@@ -128,7 +129,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Points of interest function error:', error);
+    logger.error('Points of interest function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-price-confirm/index.ts
+++ b/supabase/functions/amadeus-price-confirm/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -33,7 +34,7 @@ const getAmadeusAccessToken = async (): Promise<string> => {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus auth failed:', errorText);
+    logger.error('Amadeus auth failed:', errorText);
     throw new Error(`Amadeus auth failed: ${response.statusText}`);
   }
 
@@ -42,7 +43,7 @@ const getAmadeusAccessToken = async (): Promise<string> => {
 };
 
 const confirmHotelPrice = async (offerId: string, accessToken: string) => {
-  console.log('Amadeus Price Confirmation API call:', `https://test.api.amadeus.com/v3/shopping/hotel-offers/${offerId}`);
+  logger.info('Amadeus Price Confirmation API call:', `https://test.api.amadeus.com/v3/shopping/hotel-offers/${offerId}`);
 
   const response = await fetch(
     `https://test.api.amadeus.com/v3/shopping/hotel-offers/${offerId}`,
@@ -56,7 +57,7 @@ const confirmHotelPrice = async (offerId: string, accessToken: string) => {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus price confirmation error:', {
+    logger.error('Amadeus price confirmation error:', {
       status: response.status,
       statusText: response.statusText,
       error: errorText,
@@ -66,7 +67,7 @@ const confirmHotelPrice = async (offerId: string, accessToken: string) => {
   }
 
   const result = await response.json();
-  console.log('Amadeus Price Confirmation API response:', {
+  logger.info('Amadeus Price Confirmation API response:', {
     offerId: result.data?.id,
     available: result.data?.available,
     priceTotal: result.data?.offers?.[0]?.price?.total
@@ -83,7 +84,7 @@ serve(async (req) => {
   try {
     const { offerId } = await req.json();
 
-    console.log('=== Amadeus Price Confirmation Request ===', {
+    logger.info('=== Amadeus Price Confirmation Request ===', {
       offerId
     });
 
@@ -134,7 +135,7 @@ serve(async (req) => {
       lastUpdated: new Date().toISOString()
     };
 
-    console.log(`=== Price Confirmation Complete ===`, {
+    logger.info(`=== Price Confirmation Complete ===`, {
       offerId: offer?.id,
       available: offer?.available,
       confirmationSuccess: true
@@ -154,7 +155,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('=== Amadeus Price Confirmation Error ===', {
+    logger.error('=== Amadeus Price Confirmation Error ===', {
       error: error.message,
       stack: error.stack,
       timestamp: new Date().toISOString()

--- a/supabase/functions/amadeus-safe-place/index.ts
+++ b/supabase/functions/amadeus-safe-place/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -42,7 +43,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 async function getSafetyRating(latitude: number, longitude: number, accessToken: string) {
   const url = `https://test.api.amadeus.com/v1/safety/safety-rated-locations?latitude=${latitude}&longitude=${longitude}`;
   
-  console.log('Getting safety rating for coordinates:', latitude, longitude);
+  logger.info('Getting safety rating for coordinates:', latitude, longitude);
   
   const response = await fetch(url, {
     headers: {
@@ -52,12 +53,12 @@ async function getSafetyRating(latitude: number, longitude: number, accessToken:
   });
 
   if (!response.ok) {
-    console.error('Safe Place API error:', response.status, response.statusText);
+    logger.error('Safe Place API error:', response.status, response.statusText);
     throw new Error(`Safe Place API error: ${response.statusText}`);
   }
 
   const data = await response.json();
-  console.log('Safe Place response:', data);
+  logger.info('Safe Place response:', data);
   return data;
 }
 
@@ -77,11 +78,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Safety rating request for coordinates:', latitude, longitude);
+    logger.info('Safety rating request for coordinates:', latitude, longitude);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for safety rating');
+    logger.info('Got Amadeus access token for safety rating');
 
     // Get safety rating
     const safetyData = await getSafetyRating(parseFloat(latitude), parseFloat(longitude), accessToken);
@@ -110,7 +111,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Safety rating function error:', error);
+    logger.error('Safety rating function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-seat-map/index.ts
+++ b/supabase/functions/amadeus-seat-map/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -46,7 +47,7 @@ async function getAmadeusAccessToken(): Promise<string> {
 async function getSeatMap(params: SeatMapParams, accessToken: string) {
   const url = 'https://test.api.amadeus.com/v1/shopping/seatmaps';
   
-  console.log('Getting seat map for flight offer ID:', params.flightOfferId);
+  logger.info('Getting seat map for flight offer ID:', params.flightOfferId);
   
   const body = {
     data: [
@@ -67,12 +68,12 @@ async function getSeatMap(params: SeatMapParams, accessToken: string) {
   });
 
   if (!response.ok) {
-    console.error('Seat Map API error:', response.status, response.statusText);
+    logger.error('Seat Map API error:', response.status, response.statusText);
     throw new Error(`Seat Map API error: ${response.statusText}`);
   }
 
   const data = await response.json();
-  console.log('Seat Map response:', data);
+  logger.info('Seat Map response:', data);
   return data;
 }
 
@@ -92,11 +93,11 @@ serve(async (req) => {
       );
     }
 
-    console.log('Seat map request for flight offer:', flightOfferId);
+    logger.info('Seat map request for flight offer:', flightOfferId);
 
     // Get access token
     const accessToken = await getAmadeusAccessToken();
-    console.log('Got Amadeus access token for seat map');
+    logger.info('Got Amadeus access token for seat map');
 
     // Get seat map
     const seatMapData = await getSeatMap({ flightOfferId }, accessToken);
@@ -152,7 +153,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Seat map function error:', error);
+    logger.error('Seat map function error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/amadeus-tours-activities/index.ts
+++ b/supabase/functions/amadeus-tours-activities/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -67,7 +68,7 @@ const searchToursActivities = async (params: ToursActivitiesParams, accessToken:
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Amadeus tours/activities search error:', errorText);
+    logger.error('Amadeus tours/activities search error:', errorText);
     throw new Error(`Tours/activities search failed: ${response.statusText} - ${errorText}`);
   }
 
@@ -82,7 +83,7 @@ serve(async (req) => {
   try {
     const { destination, date, participants = 1 } = await req.json();
 
-    console.log('Amadeus tours/activities search:', { destination, date, participants });
+    logger.info('Amadeus tours/activities search:', { destination, date, participants });
 
     // Get coordinates for destination (simplified mapping)
     const locationMap: { [key: string]: { lat: number; lng: number } } = {
@@ -218,7 +219,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Amadeus tours/activities search error:', error);
+    logger.error('Amadeus tours/activities search error:', error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message,

--- a/supabase/functions/create-card-payment-intent/index.ts
+++ b/supabase/functions/create-card-payment-intent/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -28,7 +29,7 @@ serve(async (req) => {
   try {
     const body: BookingPaymentParams = await req.json();
     const { bookingType, bookingData, amount, currency, customerInfo } = (body as any) ?? {};
-    console.log('create-card-payment-intent init', {
+    logger.info('create-card-payment-intent init', {
       bookingType,
       amount,
       currency,
@@ -62,7 +63,7 @@ serve(async (req) => {
     if (!customerInfo?.email) errors.customerEmail = 'customerInfo.email is required';
 
     if (Object.keys(errors).length > 0) {
-      console.error('Validation failed for create-card-payment-intent', { errors, body });
+      logger.error('Validation failed for create-card-payment-intent', { errors, body });
       return new Response(
         JSON.stringify({ success: false, error: 'Invalid request parameters', details: errors }),
         { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 422 }
@@ -139,7 +140,7 @@ serve(async (req) => {
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
     );
   } catch (error) {
-    console.error('create-card-payment-intent error:', error);
+    logger.error('create-card-payment-intent error:', error);
     return new Response(
       JSON.stringify({ success: false, error: (error as Error).message || 'Unknown error' }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 }

--- a/supabase/functions/create-gift-card/index.ts
+++ b/supabase/functions/create-gift-card/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 import { Resend } from "npm:resend@2.0.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -63,7 +64,7 @@ serve(async (req) => {
       .rpc('generate_gift_card_code');
     
     if (codeError || !codeData) {
-      console.error("Gift card code generation error:", codeError);
+      logger.error("Gift card code generation error:", codeError);
       throw new Error(`Failed to generate gift card code: ${codeError?.message || 'Unknown error'}`);
     }
     const giftCardCode = codeData;
@@ -114,11 +115,11 @@ serve(async (req) => {
       });
 
     if (insertError) {
-      console.error("Gift card insert error:", insertError);
+      logger.error("Gift card insert error:", insertError);
       throw new Error("Failed to create gift card record");
     }
 
-    console.log("Gift card created successfully:", giftCardCode);
+    logger.info("Gift card created successfully:", giftCardCode);
 
     return new Response(JSON.stringify({ 
       success: true,
@@ -130,7 +131,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error("Error in create-gift-card function:", error);
+    logger.error("Error in create-gift-card function:", error);
     return new Response(JSON.stringify({ 
       success: false,
       error: error.message 

--- a/supabase/functions/create-hotel-booking/index.ts
+++ b/supabase/functions/create-hotel-booking/index.ts
@@ -1,5 +1,6 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
 import { createClient } from 'jsr:@supabase/supabase-js@2'
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -66,7 +67,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    console.log('Creating hotel booking:', { hotelId, offerId, checkIn, checkOut, adults, children, rooms });
+    logger.info('Creating hotel booking:', { hotelId, offerId, checkIn, checkOut, adults, children, rooms });
 
     // Re-fetch the offer from Amadeus to get accurate pricing
     const { data: hotelData, error: hotelError } = await supabaseClient.functions.invoke(
@@ -146,7 +147,7 @@ Deno.serve(async (req) => {
       .single();
 
     if (bookingError) {
-      console.error('Booking creation error:', bookingError);
+      logger.error('Booking creation error:', bookingError);
       throw new Error('Failed to create booking record');
     }
 
@@ -176,7 +177,7 @@ Deno.serve(async (req) => {
     const paymentIntent = await stripeResponse.json();
 
     if (!stripeResponse.ok) {
-      console.error('Stripe error:', paymentIntent);
+      logger.error('Stripe error:', paymentIntent);
       throw new Error('Failed to create payment intent');
     }
 
@@ -192,10 +193,10 @@ Deno.serve(async (req) => {
       });
 
     if (paymentError) {
-      console.error('Payment record error:', paymentError);
+      logger.error('Payment record error:', paymentError);
     }
 
-    console.log(`✅ Created hotel booking ${booking.id} with payment intent ${paymentIntent.id}`);
+    logger.info(`✅ Created hotel booking ${booking.id} with payment intent ${paymentIntent.id}`);
 
     return new Response(
       JSON.stringify({
@@ -213,7 +214,7 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Create hotel booking error:', error);
+    logger.error('Create hotel booking error:', error);
     return new Response(
       JSON.stringify({
         success: false,

--- a/supabase/functions/create-partner-checkout/index.ts
+++ b/supabase/functions/create-partner-checkout/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -9,7 +10,7 @@ const corsHeaders = {
 
 const logStep = (step: string, details?: any) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
-  console.log(`[CREATE-PARTNER-CHECKOUT] ${step}${detailsStr}`);
+  logger.info(`[CREATE-PARTNER-CHECKOUT] ${step}${detailsStr}`);
 };
 
 serve(async (req) => {

--- a/supabase/functions/flight-search/index.ts
+++ b/supabase/functions/flight-search/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,7 +15,7 @@ serve(async (req) => {
   try {
     const { origin, destination, departureDate, returnDate, passengers } = await req.json();
 
-    console.log('Flight search request:', {
+    logger.info('Flight search request:', {
       origin,
       destination,
       departureDate,
@@ -179,7 +180,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Flight search error:', error);
+    logger.error('Flight search error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/generate-offers/index.ts
+++ b/supabase/functions/generate-offers/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -18,7 +19,7 @@ serve(async (req) => {
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     )
 
-    console.log('Generating dynamic offers...')
+    logger.info('Generating dynamic offers...')
 
     // TODO: Integrate with travel APIs to get real pricing data
     // For now, generate sample offers based on popular routes
@@ -65,7 +66,7 @@ serve(async (req) => {
       .select()
 
     if (error) {
-      console.error('Database error:', error)
+      logger.error('Database error:', error)
       return new Response(
         JSON.stringify({ error: 'Failed to generate offers' }),
         { 
@@ -75,7 +76,7 @@ serve(async (req) => {
       )
     }
 
-    console.log(`Generated ${data.length} new offers`)
+    logger.info(`Generated ${data.length} new offers`)
 
     return new Response(
       JSON.stringify({
@@ -90,7 +91,7 @@ serve(async (req) => {
     )
 
   } catch (error) {
-    console.error('Function error:', error)
+    logger.error('Function error:', error)
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
       { 

--- a/supabase/functions/get-stripe-publishable-key/index.ts
+++ b/supabase/functions/get-stripe-publishable-key/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -24,7 +25,7 @@ serve(async (req) => {
       }
     );
   } catch (error) {
-    console.error('Error getting Stripe publishable key:', error);
+    logger.error('Error getting Stripe publishable key:', error);
     
     return new Response(
       JSON.stringify({ error: error.message }),

--- a/supabase/functions/guest-booking-lookup/index.ts
+++ b/supabase/functions/guest-booking-lookup/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -25,7 +26,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
         Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
       );
 
-    console.log('Looking up booking:', { bookingReference, email });
+    logger.info('Looking up booking:', { bookingReference, email });
 
     // Get booking by reference
     const { data: booking, error: bookingError } = await client
@@ -35,7 +36,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
       .single();
 
     if (bookingError || !booking) {
-      console.error('Booking not found:', bookingError?.message);
+      logger.error('Booking not found:', bookingError?.message);
       throw new Error('Booking not found');
     }
 
@@ -48,7 +49,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
       });
 
     if (verifyError || !hasAccess) {
-      console.error('Access verification failed:', verifyError?.message);
+      logger.error('Access verification failed:', verifyError?.message);
       
       // Log failed access attempt
       await client.rpc('log_booking_access', {
@@ -77,7 +78,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
       .eq('booking_id', booking.id);
 
     if (itemsError) {
-      console.error('Failed to fetch booking items:', itemsError);
+      logger.error('Failed to fetch booking items:', itemsError);
     }
 
     // Get latest payment
@@ -90,7 +91,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
       .single();
 
     if (paymentError && paymentError.code !== 'PGRST116') {
-      console.error('Failed to fetch payment:', paymentError);
+      logger.error('Failed to fetch payment:', paymentError);
     }
 
     // Prepare response data
@@ -108,7 +109,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
       latest_payment: latestPayment || null
     };
 
-    console.log('Booking lookup successful:', booking.booking_reference);
+    logger.info('Booking lookup successful:', booking.booking_reference);
 
     return new Response(
       JSON.stringify({
@@ -120,7 +121,7 @@ export async function handler(req: Request, supabaseClient?: any): Promise<Respo
       }
     );
   } catch (error) {
-    console.error('Guest booking lookup error:', error);
+    logger.error('Guest booking lookup error:', error);
 
     return new Response(
       JSON.stringify({

--- a/supabase/functions/hotel-search/index.ts
+++ b/supabase/functions/hotel-search/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,7 +15,7 @@ serve(async (req) => {
   try {
     const { destination, checkIn, checkOut, guests } = await req.json();
 
-    console.log('Hotel search request:', {
+    logger.info('Hotel search request:', {
       destination,
       checkIn,
       checkOut,
@@ -189,7 +190,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Hotel search error:', error);
+    logger.error('Hotel search error:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/hotelbeds-autocomplete/index.ts
+++ b/supabase/functions/hotelbeds-autocomplete/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -94,11 +95,11 @@ async function fetchDestinationsPaged(qLower: string, max: number) {
       }
       if (items.length < batch) break; // no more pages
     } catch (e) {
-      console.error("HotelBeds destinations page error:", e);
+      logger.error("HotelBeds destinations page error:", e);
       break;
     }
   }
-  console.log("hotelbeds-autocomplete destinations scanned=%d matched=%d", scanned, out.length);
+  logger.info("hotelbeds-autocomplete destinations scanned=%d matched=%d", scanned, out.length);
   return out;
 }
 
@@ -131,11 +132,11 @@ async function fetchHotelsPaged(qLower: string, max: number) {
       }
       if (items.length < batch) break;
     } catch (e) {
-      console.error("HotelBeds hotels page error:", e);
+      logger.error("HotelBeds hotels page error:", e);
       break;
     }
   }
-  console.log("hotelbeds-autocomplete hotels scanned=%d matched=%d", scanned, out.length);
+  logger.info("hotelbeds-autocomplete hotels scanned=%d matched=%d", scanned, out.length);
   return out;
 }
 
@@ -173,7 +174,7 @@ serve(async (req) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (err) {
-    console.error("hotelbeds-autocomplete error:", err);
+    logger.error("hotelbeds-autocomplete error:", err);
     return new Response(JSON.stringify({ error: String((err as Error).message || err) }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
       status: 500,

--- a/supabase/functions/hotelbeds-search/index.ts
+++ b/supabase/functions/hotelbeds-search/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createHash } from "https://deno.land/std@0.190.0/crypto/crypto.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -87,7 +88,7 @@ serve(async (req) => {
       rooms = 1 
     } = await req.json();
 
-    console.log('HotelBeds hotel search:', { destination, checkIn, checkOut, guests, rooms });
+    logger.info('HotelBeds hotel search:', { destination, checkIn, checkOut, guests, rooms });
 
     // For demo, we'll use a destination code mapping
     // In production, you'd have a proper destination mapping system
@@ -165,7 +166,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('HotelBeds search error:', error);
+    logger.error('HotelBeds search error:', error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message,

--- a/supabase/functions/rate-limiter/index.ts
+++ b/supabase/functions/rate-limiter/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -66,7 +67,7 @@ serve(async (req) => {
       .gte('created_at', new Date(windowStart * 1000).toISOString());
 
     if (error) {
-      console.error("Error checking rate limits:", error);
+      logger.error("Error checking rate limits:", error);
       // In case of database error, allow the request to proceed
       return new Response(JSON.stringify({
         allowed: true,
@@ -129,7 +130,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error("Rate limiter error:", error);
+    logger.error("Rate limiter error:", error);
     return new Response(JSON.stringify({
       allowed: true, // Default to allow in case of errors
       error: error.message

--- a/supabase/functions/sabre-flight-offers/index.ts
+++ b/supabase/functions/sabre-flight-offers/index.ts
@@ -1,4 +1,5 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -40,7 +41,7 @@ async function getSabreAccessToken(): Promise<string> {
   });
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre auth error:', errorText);
+    logger.error('Sabre auth error:', errorText);
     throw new Error('Failed to authenticate with Sabre API');
   }
   const data: SabreAuthResponse = await response.json();
@@ -102,7 +103,7 @@ async function searchOffers(params: FlightOfferParams, accessToken: string): Pro
   });
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre search error:', errorText);
+    logger.error('Sabre search error:', errorText);
     throw new Error(`Sabre API error: ${response.status} ${response.statusText}`);
   }
   return response.json();
@@ -151,7 +152,7 @@ function transformSabreOffers(sabreData: any): any[] {
       }
     }
   } catch (error) {
-    console.error('Error transforming Sabre response:', error);
+    logger.error('Error transforming Sabre response:', error);
     return [];
   }
   return flights;
@@ -162,7 +163,7 @@ Deno.serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
   try {
-    console.log('Sabre flight offers request received');
+    logger.info('Sabre flight offers request received');
     const body = await req.json();
     const {
       origin,
@@ -193,7 +194,7 @@ Deno.serve(async (req) => {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   } catch (error) {
-    console.error('Sabre flight offers error:', error);
+    logger.error('Sabre flight offers error:', error);
     return new Response(JSON.stringify({ success: false, error: String(error) }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/sabre-flight-search/index.ts
+++ b/supabase/functions/sabre-flight-search/index.ts
@@ -45,7 +45,7 @@ async function getSabreAccessToken(): Promise<string> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre auth error:', errorText);
+    logger.error('Sabre auth error:', errorText);
     throw new Error('Failed to authenticate with Sabre API');
   }
 
@@ -139,7 +139,7 @@ async function searchFlights(params: FlightSearchParams, accessToken: string): P
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre flight search error:', errorText);
+    logger.error('Sabre flight search error:', errorText);
     throw new Error(`Sabre API error: ${response.status} ${response.statusText}`);
   }
 
@@ -152,7 +152,7 @@ function transformSabreResponse(sabreData: any): any[] {
     const flights: any[] = [];
     
     if (!sabreData?.OTA_AirLowFareSearchRS?.PricedItineraries?.PricedItinerary) {
-      console.log('No flights found in Sabre response');
+      logger.info('No flights found in Sabre response');
       return flights;
     }
 
@@ -234,7 +234,7 @@ function transformSabreResponse(sabreData: any): any[] {
 
     return flights.slice(0, 50); // Limit to 50 results
   } catch (error) {
-    console.error('Error transforming Sabre response:', error);
+    logger.error('Error transforming Sabre response:', error);
     return [];
   }
 }
@@ -246,7 +246,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    console.log('Sabre flight search request received');
+    logger.info('Sabre flight search request received');
     
     const body = await req.json();
     const {
@@ -272,10 +272,10 @@ Deno.serve(async (req) => {
       );
     }
 
-    console.log('Getting Sabre access token...');
+    logger.info('Getting Sabre access token...');
     const accessToken = await getSabreAccessToken();
     
-    console.log('Searching flights with Sabre...');
+    logger.info('Searching flights with Sabre...');
     const searchParams: FlightSearchParams = {
       origin,
       destination,
@@ -286,7 +286,7 @@ Deno.serve(async (req) => {
     };
 
     const sabreData = await searchFlights(searchParams, accessToken);
-    console.log('Sabre flight data received, transforming...');
+    logger.info('Sabre flight data received, transforming...');
     
     const transformedFlights = transformSabreResponse(sabreData);
     
@@ -305,7 +305,7 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Error in sabre-flight-search:', error);
+    logger.error('Error in sabre-flight-search:', error);
     return new Response(
       JSON.stringify({
         success: false,

--- a/supabase/functions/sabre-hotel-search/index.ts
+++ b/supabase/functions/sabre-hotel-search/index.ts
@@ -44,7 +44,7 @@ async function getSabreAccessToken(): Promise<string> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre auth error:', errorText);
+    logger.error('Sabre auth error:', errorText);
     throw new Error('Failed to authenticate with Sabre API');
   }
 
@@ -107,7 +107,7 @@ async function searchHotels(params: HotelSearchParams, accessToken: string): Pro
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre hotel search error:', errorText);
+    logger.error('Sabre hotel search error:', errorText);
     throw new Error(`Sabre API error: ${response.status} ${response.statusText}`);
   }
 
@@ -120,7 +120,7 @@ function transformSabreHotelResponse(sabreData: any): any[] {
     const hotels: any[] = [];
     
     if (!sabreData?.GetHotelAvailRS?.HotelAvailInfos?.HotelAvailInfo) {
-      console.log('No hotels found in Sabre response');
+      logger.info('No hotels found in Sabre response');
       return hotels;
     }
 
@@ -220,7 +220,7 @@ function transformSabreHotelResponse(sabreData: any): any[] {
 
     return hotels.slice(0, 50); // Limit to 50 results
   } catch (error) {
-    console.error('Error transforming Sabre hotel response:', error);
+    logger.error('Error transforming Sabre hotel response:', error);
     return [];
   }
 }
@@ -232,7 +232,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    console.log('Sabre hotel search request received');
+    logger.info('Sabre hotel search request received');
     
     const body = await req.json();
     const {
@@ -258,10 +258,10 @@ Deno.serve(async (req) => {
       );
     }
 
-    console.log('Getting Sabre access token...');
+    logger.info('Getting Sabre access token...');
     const accessToken = await getSabreAccessToken();
     
-    console.log('Searching hotels with Sabre...');
+    logger.info('Searching hotels with Sabre...');
     const searchParams: HotelSearchParams = {
       cityCode,
       checkIn,
@@ -272,7 +272,7 @@ Deno.serve(async (req) => {
     };
 
     const sabreData = await searchHotels(searchParams, accessToken);
-    console.log('Sabre hotel data received, transforming...');
+    logger.info('Sabre hotel data received, transforming...');
     
     const transformedHotels = transformSabreHotelResponse(sabreData);
     
@@ -291,7 +291,7 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Error in sabre-hotel-search:', error);
+    logger.error('Error in sabre-hotel-search:', error);
     return new Response(
       JSON.stringify({
         success: false,

--- a/supabase/functions/sabre-locations-autocomplete/index.ts
+++ b/supabase/functions/sabre-locations-autocomplete/index.ts
@@ -32,7 +32,7 @@ async function getSabreAccessToken(): Promise<string> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error('Sabre auth error:', errorText);
+    logger.error('Sabre auth error:', errorText);
     throw new Error('Failed to authenticate with Sabre API');
   }
 
@@ -67,10 +67,10 @@ async function searchLocations(query: string, limit: number, accessToken: string
         const data = await response.json();
         results.push(data);
       } else {
-        console.warn(`Sabre endpoint ${endpoint} returned ${response.status}`);
+        logger.warn(`Sabre endpoint ${endpoint} returned ${response.status}`);
       }
     } catch (error) {
-      console.warn(`Error calling Sabre endpoint ${endpoint}:`, error);
+      logger.warn(`Error calling Sabre endpoint ${endpoint}:`, error);
     }
   }
 
@@ -164,7 +164,7 @@ function transformSabreLocationResponse(sabreResults: any[]): any[] {
 
     return uniqueLocations.slice(0, 20); // Limit results
   } catch (error) {
-    console.error('Error transforming Sabre location response:', error);
+    logger.error('Error transforming Sabre location response:', error);
     return [];
   }
 }
@@ -176,7 +176,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    console.log('Sabre locations autocomplete request received');
+    logger.info('Sabre locations autocomplete request received');
     
     const body = await req.json();
     const { query, limit = 10 } = body;
@@ -195,13 +195,13 @@ Deno.serve(async (req) => {
       );
     }
 
-    console.log('Getting Sabre access token...');
+    logger.info('Getting Sabre access token...');
     const accessToken = await getSabreAccessToken();
     
-    console.log(`Searching locations for query: ${query}`);
+    logger.info(`Searching locations for query: ${query}`);
     const sabreResults = await searchLocations(query, limit, accessToken);
     
-    console.log('Sabre location data received, transforming...');
+    logger.info('Sabre location data received, transforming...');
     const transformedLocations = transformSabreLocationResponse(sabreResults);
     
     return new Response(
@@ -219,7 +219,7 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Error in sabre-locations-autocomplete:', error);
+    logger.error('Error in sabre-locations-autocomplete:', error);
     return new Response(
       JSON.stringify({
         success: false,

--- a/supabase/functions/security-cleanup/index.ts
+++ b/supabase/functions/security-cleanup/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -25,17 +26,17 @@ serve(async (req) => {
       { auth: { persistSession: false } }
     );
 
-    console.log("Starting security cleanup process...");
+    logger.info("Starting security cleanup process...");
 
     // Run the guest data cleanup function
     const { data, error } = await supabaseClient.rpc('cleanup_guest_data');
 
     if (error) {
-      console.error("Guest data cleanup failed:", error);
+      logger.error("Guest data cleanup failed:", error);
       throw new Error(`Cleanup failed: ${error.message}`);
     }
 
-    console.log("Guest data cleanup completed successfully");
+    logger.info("Guest data cleanup completed successfully");
 
     return new Response(JSON.stringify({
       success: true,
@@ -47,7 +48,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error("Security cleanup error:", error);
+    logger.error("Security cleanup error:", error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message,

--- a/supabase/functions/send-booking-confirmation/index.ts
+++ b/supabase/functions/send-booking-confirmation/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
 import { Resend } from "npm:resend@2.0.0"
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -169,7 +170,7 @@ serve(async (req) => {
       html: emailContent.html,
     });
 
-    console.log('Confirmation email sent successfully:', emailResponse);
+    logger.info('Confirmation email sent successfully:', emailResponse);
 
     return new Response(
       JSON.stringify({ 
@@ -182,7 +183,7 @@ serve(async (req) => {
       }
     );
   } catch (error) {
-    console.error('Error sending confirmation email:', error);
+    logger.error('Error sending confirmation email:', error);
     
     return new Response(
       JSON.stringify({

--- a/supabase/functions/send-gift-card-email/index.ts
+++ b/supabase/functions/send-gift-card-email/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 import { Resend } from "npm:resend@2.0.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -186,7 +187,7 @@ serve(async (req) => {
       throw new Error(`Failed to send email: ${emailResponse.error.message}`);
     }
 
-    console.log("Gift card email sent successfully:", giftCardCode);
+    logger.info("Gift card email sent successfully:", giftCardCode);
 
     return new Response(JSON.stringify({ 
       success: true,
@@ -197,7 +198,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error("Error in send-gift-card-email function:", error);
+    logger.error("Error in send-gift-card-email function:", error);
     return new Response(JSON.stringify({ 
       success: false,
       error: error.message 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -15,7 +16,7 @@ const corsHeaders = {
 
 const logStep = (step: string, details?: any) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
-  console.log(`[STRIPE-WEBHOOK] ${step}${detailsStr}`);
+  logger.info(`[STRIPE-WEBHOOK] ${step}${detailsStr}`);
 };
 
 serve(async (req) => {

--- a/supabase/functions/travelport-search/index.ts
+++ b/supabase/functions/travelport-search/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -118,7 +119,7 @@ serve(async (req) => {
     const searchParams = await req.json();
     const { type } = searchParams;
 
-    console.log('Travelport search:', { type, ...searchParams });
+    logger.info('Travelport search:', { type, ...searchParams });
 
     let results;
     let transformedData = [];
@@ -209,7 +210,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Travelport search error:', error);
+    logger.error('Travelport search error:', error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message,

--- a/supabase/functions/unified-search/index.ts
+++ b/supabase/functions/unified-search/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -41,7 +42,7 @@ const callEdgeFunction = async (functionName: string, payload: any) => {
   });
 
   if (error) {
-    console.warn(`${functionName} search failed:`, error);
+    logger.warn(`${functionName} search failed:`, error);
     return null;
   }
 
@@ -86,7 +87,7 @@ serve(async (req) => {
     const params: SearchParams = await req.json();
     const { type, providers = ['amadeus', 'hotelbeds', 'travelport'] } = params;
 
-    console.log('Unified search:', { type, providers, ...params });
+    logger.info('Unified search:', { type, providers, ...params });
 
     const searchPromises = [];
 
@@ -177,7 +178,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('Unified search error:', error);
+    logger.error('Unified search error:', error);
     return new Response(JSON.stringify({
       success: false,
       error: error.message,

--- a/supabase/functions/validate-gift-card/index.ts
+++ b/supabase/functions/validate-gift-card/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -91,7 +92,7 @@ serve(async (req) => {
       });
     }
 
-    console.log("Gift card validated successfully:", code);
+    logger.info("Gift card validated successfully:", code);
 
     return new Response(JSON.stringify({ 
       success: true,
@@ -111,7 +112,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error("Error in validate-gift-card function:", error);
+    logger.error("Error in validate-gift-card function:", error);
     return new Response(JSON.stringify({ 
       success: false,
       error: error.message 

--- a/supabase/functions/validate-passport/index.ts
+++ b/supabase/functions/validate-passport/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -22,7 +23,7 @@ serve(async (req) => {
 
     // TODO: Integrate with OCR service (AWS Textract, Google Vision, etc.)
     // For now, simulate validation logic
-    console.log(`Validating passport for user ${userId} with image: ${passportImageUrl}`)
+    logger.info(`Validating passport for user ${userId} with image: ${passportImageUrl}`)
 
     // Simulate OCR extraction
     const mockOcrResult = {
@@ -48,7 +49,7 @@ serve(async (req) => {
       .single()
 
     if (error) {
-      console.error('Database error:', error)
+      logger.error('Database error:', error)
       return new Response(
         JSON.stringify({ error: 'Failed to update passport info' }),
         { 
@@ -72,7 +73,7 @@ serve(async (req) => {
     )
 
   } catch (error) {
-    console.error('Function error:', error)
+    logger.error('Function error:', error)
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
       { 

--- a/supabase/functions/verify-partner-payment/index.ts
+++ b/supabase/functions/verify-partner-payment/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import logger from "../_shared/logger.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -9,7 +10,7 @@ const corsHeaders = {
 
 const logStep = (step: string, details?: any) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
-  console.log(`[VERIFY-PARTNER-PAYMENT] ${step}${detailsStr}`);
+  logger.info(`[VERIFY-PARTNER-PAYMENT] ${step}${detailsStr}`);
 };
 
 serve(async (req) => {


### PR DESCRIPTION
## Summary
- add shared pino logger with environment-driven log level
- replace console statements across Supabase functions with logger calls
- include pino dependency for runtime logging

## Testing
- `npm test` *(fails: Only URLs with a scheme in: file and data are supported by the default ESM loader. Received protocol 'https:' in supabase/functions/guest-booking-lookup/index.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a702bfa8708324add36074b3001b72