### PR TITLE
refactor: replace console error and warn with logger

### DIFF
--- a/src/components/SeatMapDialog.tsx
+++ b/src/components/SeatMapDialog.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Loader2, Plane, X } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 interface SeatMapDialogProps {
   open: boolean;
@@ -80,7 +81,7 @@ export const SeatMapDialog = ({ open, onOpenChange, flightOfferId, onSeatSelecte
         throw new Error('No seat map data available');
       }
     } catch (err) {
-      console.error('Seat map error:', err);
+      logger.error('Seat map error:', err);
       setError(err instanceof Error ? err.message : 'Failed to load seat map');
       toast.error('Failed to load seat map');
     } finally {

--- a/src/components/SystemHealthIndicator.tsx
+++ b/src/components/SystemHealthIndicator.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { AlertCircle, CheckCircle, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import logger from "@/utils/logger";
 
 interface SystemHealthIndicatorProps {
   className?: string;
@@ -38,7 +39,7 @@ export const SystemHealthIndicator = ({ className }: SystemHealthIndicatorProps)
           setHealthStatus('unavailable');
         }
       } catch (error) {
-        console.error('Health check failed:', error);
+        logger.error('Health check failed:', error);
         setHealthStatus('unavailable');
         setLastCheck(new Date());
       }

--- a/src/components/TestModeIndicator.tsx
+++ b/src/components/TestModeIndicator.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { TestTube, CreditCard, AlertTriangle, CheckCircle } from 'lucide-react';
+import logger from "@/utils/logger";
 
 interface TestCard {
   type: string;
@@ -40,7 +41,7 @@ const TestModeIndicator: React.FC<TestModeIndicatorProps> = ({
       setCopiedCard(text);
       setTimeout(() => setCopiedCard(null), 2000);
     } catch (err) {
-      console.error('Failed to copy:', err);
+      logger.error('Failed to copy:', err);
     }
   };
 

--- a/src/components/dashboard/BookingManagementDashboard.tsx
+++ b/src/components/dashboard/BookingManagementDashboard.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { 
+import logger from "@/utils/logger";
   Search, 
   Filter, 
   Calendar, 
@@ -72,7 +73,7 @@ export const BookingManagementDashboard = () => {
       const { data, error } = await supabase.rpc('get_user_bookings');
       
       if (error) {
-        console.error('Error fetching bookings:', error);
+        logger.error('Error fetching bookings:', error);
         toast({
           title: "Error",
           description: "Failed to load your bookings. Please try again.",
@@ -85,7 +86,7 @@ export const BookingManagementDashboard = () => {
       setBookings(bookingsArray);
       
     } catch (err) {
-      console.error('Fetch bookings exception:', err);
+      logger.error('Fetch bookings exception:', err);
       toast({
         title: "Error",
         description: "Failed to load your bookings. Please try again.",
@@ -131,7 +132,7 @@ export const BookingManagementDashboard = () => {
         throw new Error(result.message);
       }
     } catch (error) {
-      console.error('Error cancelling booking:', error);
+      logger.error('Error cancelling booking:', error);
       toast({
         title: "Error",
         description: "Failed to cancel booking. Please try again.",

--- a/src/components/dashboard/MyTripsSection.tsx
+++ b/src/components/dashboard/MyTripsSection.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Separator } from '@/components/ui/separator';
 import { useToast } from '@/hooks/use-toast';
 import { 
+import logger from "@/utils/logger";
   Plane, 
   Building, 
   Car, 
@@ -74,7 +75,7 @@ export const MyTripsSection: React.FC = () => {
         .order('created_at', { ascending: false });
 
       if (bookingsError) {
-        console.error('Bookings fetch error:', bookingsError);
+        logger.error('Bookings fetch error:', bookingsError);
         toast({
           title: 'Error',
           description: 'Failed to load your bookings. Please try again.',
@@ -98,7 +99,7 @@ export const MyTripsSection: React.FC = () => {
       });
 
     } catch (error) {
-      console.error('Error fetching trips:', error);
+      logger.error('Error fetching trips:', error);
       toast({
         title: 'Error',
         description: 'Failed to load your trips. Please try again.',
@@ -175,7 +176,7 @@ export const MyTripsSection: React.FC = () => {
       // Refresh the trips data
       fetchTrips();
     } catch (error) {
-      console.error('Error cancelling order:', error);
+      logger.error('Error cancelling order:', error);
       toast({
         title: 'Error',
         description: 'Failed to cancel the booking. Please try again.',

--- a/src/components/dashboard/RealTimeFeeds.tsx
+++ b/src/components/dashboard/RealTimeFeeds.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { activityAPI } from '@/lib/otaDataClient';
 import { 
+import logger from "@/utils/logger";
   Activity, 
   MapPin, 
   Clock, 
@@ -45,7 +46,7 @@ export const RealTimeFeeds: React.FC<{ className?: string }> = ({ className }) =
         const data = await activityAPI.fetchRecentActivity(undefined, 10);
         setActivities(data || []);
       } catch (error) {
-        console.error('Error loading activities:', error);
+        logger.error('Error loading activities:', error);
       }
     };
 

--- a/src/components/dashboard/SmartAnalytics.tsx
+++ b/src/components/dashboard/SmartAnalytics.tsx
@@ -6,6 +6,7 @@ import { analyticsAPI } from '@/lib/otaDataClient';
 import { useAuth } from '@/features/auth/context/AuthContext';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 import { 
+import logger from "@/utils/logger";
   MapPin, 
   Calendar, 
   Coins, 
@@ -40,7 +41,7 @@ export const SmartAnalytics: React.FC<{ className?: string }> = ({ className }) 
         const data = await analyticsAPI.fetchTravelAnalytics(user.id);
         setAnalytics(data);
       } catch (error) {
-        console.error('Error loading analytics:', error);
+        logger.error('Error loading analytics:', error);
       } finally {
         setLoading(false);
       }

--- a/src/components/dashboard/TravelTechMetrics.tsx
+++ b/src/components/dashboard/TravelTechMetrics.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { TrendingUp, Zap, Globe, Activity, Eye, BookOpen, Star } from 'lucide-react';
 import { activityAPI } from '@/lib/otaDataClient';
+import logger from "@/utils/logger";
 interface TechMetrics {
   aiPoweredRecommendations: number;
   priceIntelligenceAccuracy: number;
@@ -32,7 +33,7 @@ export const TravelTechMetrics: React.FC<{
         const activity = await activityAPI.fetchRecentActivity(undefined, 5);
         setRecentActivity(activity || []);
       } catch (error) {
-        console.error('Error loading recent activity:', error);
+        logger.error('Error loading recent activity:', error);
       }
     };
     loadRecentActivity();

--- a/src/components/dream-map/InteractiveWorldMap.tsx
+++ b/src/components/dream-map/InteractiveWorldMap.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
+import logger from "@/utils/logger";
 
 // Fix Leaflet default markers
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -111,7 +112,7 @@ const InteractiveWorldMap: React.FC = () => {
     user = authResult.user;
     console.log('InteractiveWorldMap: useAuth result:', { user: !!user });
   } catch (error) {
-    console.error('InteractiveWorldMap: useAuth error:', error);
+    logger.error('InteractiveWorldMap: useAuth error:', error);
     setMapError('Authentication error');
   }
 
@@ -131,7 +132,7 @@ const InteractiveWorldMap: React.FC = () => {
       if (error) throw error;
       setDestinations(data || []);
     } catch (error) {
-      console.error('Error fetching destinations:', error);
+      logger.error('Error fetching destinations:', error);
       toast({
         title: "Error",
         description: "Failed to load destinations",
@@ -152,7 +153,7 @@ const InteractiveWorldMap: React.FC = () => {
       if (error) throw error;
       setBookmarks(data || []);
     } catch (error) {
-      console.error('Error fetching bookmarks:', error);
+      logger.error('Error fetching bookmarks:', error);
     }
   };
 
@@ -192,7 +193,7 @@ const InteractiveWorldMap: React.FC = () => {
         description: "Destination added to your dream board!",
       });
     } catch (error) {
-      console.error('Error adding bookmark:', error);
+      logger.error('Error adding bookmark:', error);
       toast({
         title: "Error",
         description: "Failed to add destination to dream board",
@@ -216,7 +217,7 @@ const InteractiveWorldMap: React.FC = () => {
         description: "Destination removed from your dream board",
       });
     } catch (error) {
-      console.error('Error removing bookmark:', error);
+      logger.error('Error removing bookmark:', error);
       toast({
         title: "Error",
         description: "Failed to remove destination",

--- a/src/components/dream-map/SimpleDreamMap.tsx
+++ b/src/components/dream-map/SimpleDreamMap.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
+import logger from "@/utils/logger";
 
 interface Destination {
   id: string;
@@ -76,7 +77,7 @@ const SimpleDreamMap: React.FC = () => {
       if (error) throw error;
       setDestinations(data || []);
     } catch (error) {
-      console.error('Error fetching destinations:', error);
+      logger.error('Error fetching destinations:', error);
       toast({
         title: "Error",
         description: "Failed to load destinations",
@@ -97,7 +98,7 @@ const SimpleDreamMap: React.FC = () => {
       if (error) throw error;
       setBookmarks(data || []);
     } catch (error) {
-      console.error('Error fetching bookmarks:', error);
+      logger.error('Error fetching bookmarks:', error);
     }
   };
 
@@ -128,7 +129,7 @@ const SimpleDreamMap: React.FC = () => {
         description: "Destination added to your dream board!",
       });
     } catch (error) {
-      console.error('Error adding bookmark:', error);
+      logger.error('Error adding bookmark:', error);
       toast({
         title: "Error",
         description: "Failed to add destination to dream board",
@@ -152,7 +153,7 @@ const SimpleDreamMap: React.FC = () => {
         description: "Destination removed from your dream board",
       });
     } catch (error) {
-      console.error('Error removing bookmark:', error);
+      logger.error('Error removing bookmark:', error);
     }
   };
 

--- a/src/components/hotel/HotelPhotosGallery.tsx
+++ b/src/components/hotel/HotelPhotosGallery.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { supabase } from "@/integrations/supabase/client";
+import logger from "@/utils/logger";
 
 interface HotelPhoto {
   url: string;
@@ -50,7 +51,7 @@ export const HotelPhotosGallery = ({
           setUseRealPhotos(false);
         }
       } catch (err) {
-        console.error("Failed to fetch hotel photos:", err);
+        logger.error("Failed to fetch hotel photos:", err);
         setPhotos([]);
         setUseRealPhotos(false);
       } finally {

--- a/src/components/hotel/PointsOfInterestSection.tsx
+++ b/src/components/hotel/PointsOfInterestSection.tsx
@@ -3,6 +3,7 @@ import { MapPin, Star, Clock, Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { supabase } from "@/integrations/supabase/client";
+import logger from "@/utils/logger";
 
 interface PointOfInterest {
   id: string;
@@ -62,7 +63,7 @@ export const PointsOfInterestSection = ({
           setPois(sortedPOIs);
         }
       } catch (err) {
-        console.error("Failed to fetch points of interest:", err);
+        logger.error("Failed to fetch points of interest:", err);
         setError("Failed to load nearby attractions");
       } finally {
         setLoading(false);

--- a/src/components/hotel/SmartLocationSearch.tsx
+++ b/src/components/hotel/SmartLocationSearch.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/use-toast';
+import logger from "@/utils/logger";
 
 interface LocationResult {
   name: string;
@@ -67,7 +68,7 @@ export const SmartLocationSearch: React.FC<SmartLocationSearchProps> = ({
         });
       },
       (error) => {
-        console.error('Error getting location:', error);
+        logger.error('Error getting location:', error);
         setIsGettingLocation(false);
         
         let message = "Could not access your location.";

--- a/src/components/hotel/VoiceSearchInterface.tsx
+++ b/src/components/hotel/VoiceSearchInterface.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 interface VoiceSearchInterfaceProps {
   onVoiceResult: (text: string) => void;
@@ -58,7 +59,7 @@ export const VoiceSearchInterface: React.FC<VoiceSearchInterfaceProps> = ({
       }, 10000);
 
     } catch (error) {
-      console.error('Error accessing microphone:', error);
+      logger.error('Error accessing microphone:', error);
       toast({
         title: "Microphone Access Denied",
         description: "Please allow microphone access to use voice search.",
@@ -119,7 +120,7 @@ export const VoiceSearchInterface: React.FC<VoiceSearchInterfaceProps> = ({
       };
       reader.readAsDataURL(audioBlob);
     } catch (error) {
-      console.error('Error processing audio:', error);
+      logger.error('Error processing audio:', error);
       toast({
         title: "Voice Processing Failed",
         description: "Could not process your voice input. Please try again.",
@@ -153,7 +154,7 @@ export const VoiceSearchInterface: React.FC<VoiceSearchInterfaceProps> = ({
         audio.onended = () => URL.revokeObjectURL(audioUrl);
       }
     } catch (error) {
-      console.error('Error with text-to-speech:', error);
+      logger.error('Error with text-to-speech:', error);
     }
   };
 

--- a/src/components/ota/EnhancedFavorites.tsx
+++ b/src/components/ota/EnhancedFavorites.tsx
@@ -11,6 +11,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { favoritesAPI } from '@/lib/otaDataClient';
 import { useAuth } from '@/features/auth/context/AuthContext';
 import { toast } from 'sonner';
+import logger from "@/utils/logger";
 
 interface EnhancedFavoritesProps {
   itemType: string;
@@ -80,7 +81,7 @@ export const EnhancedFavorites: React.FC<EnhancedFavoritesProps> = ({
         });
       }
     } catch (error) {
-      console.error('Error checking favorites:', error);
+      logger.error('Error checking favorites:', error);
     }
   };
 

--- a/src/components/ota/LoyaltyWidget.tsx
+++ b/src/components/ota/LoyaltyWidget.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { loyaltyAPI } from '@/lib/otaDataClient';
 import { useAuth } from '@/features/auth/context/AuthContext';
+import logger from "@/utils/logger";
 
 interface LoyaltyWidgetProps {
   className?: string;
@@ -81,7 +82,7 @@ export const LoyaltyWidget: React.FC<LoyaltyWidgetProps> = ({
       const data = await loyaltyAPI.fetchPoints(user.id);
       setLoyaltyData(data);
     } catch (error) {
-      console.error('Error loading loyalty data:', error);
+      logger.error('Error loading loyalty data:', error);
     } finally {
       setLoading(false);
     }

--- a/src/components/ota/ReviewsSection.tsx
+++ b/src/components/ota/ReviewsSection.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { reviewsAPI } from '@/lib/otaDataClient';
 import { useAuth } from '@/features/auth/context/AuthContext';
 import { toast } from 'sonner';
+import logger from "@/utils/logger";
 
 interface ReviewsSectionProps {
   itemType: string;
@@ -69,7 +70,7 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
       const data = await reviewsAPI.fetchReviews(itemType, itemId);
       setReviews(data || []);
     } catch (error) {
-      console.error('Error loading reviews:', error);
+      logger.error('Error loading reviews:', error);
     } finally {
       setLoading(false);
     }

--- a/src/components/ota/SmartRecommendations.tsx
+++ b/src/components/ota/SmartRecommendations.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { analyticsAPI, activityAPI } from '@/lib/otaDataClient';
 import { useAuth } from '@/features/auth/context/AuthContext';
+import logger from "@/utils/logger";
 interface SmartRecommendationsProps {
   currentLocation?: string;
   searchCriteria?: any;
@@ -46,7 +47,7 @@ export const SmartRecommendations: React.FC<SmartRecommendationsProps> = ({
       const analytics = await analyticsAPI.fetchTravelAnalytics(user.id);
       setUserProfile(analytics);
     } catch (error) {
-      console.error('Error loading user profile:', error);
+      logger.error('Error loading user profile:', error);
     }
   };
   const generateRecommendations = () => {

--- a/src/components/search/DestinationAutocomplete.tsx
+++ b/src/components/search/DestinationAutocomplete.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/integrations/supabase/client";
 import { AIRPORTS } from "@/data/airports";
+import logger from '@/utils/logger';
 
 interface Destination {
   id: string;
@@ -127,7 +128,7 @@ export const DestinationAutocomplete = ({
                 console.log('Found hotel results:', results.length);
               }
             } catch (hotelError) {
-              console.warn('Hotel search failed, falling back to cities:', hotelError);
+              logger.warn('Hotel search failed, falling back to cities:', hotelError);
             }
           }
 
@@ -176,7 +177,7 @@ export const DestinationAutocomplete = ({
                   });
                 }
               } catch (amadeusError) {
-                console.warn('Amadeus airport search failed, using local results:', amadeusError);
+                logger.warn('Amadeus airport search failed, using local results:', amadeusError);
               }
             }
           }
@@ -218,7 +219,7 @@ export const DestinationAutocomplete = ({
                 });
               }
             } catch (amadeusError) {
-              console.warn('Amadeus city search failed:', amadeusError);
+              logger.warn('Amadeus city search failed:', amadeusError);
             }
           }
 
@@ -235,7 +236,7 @@ export const DestinationAutocomplete = ({
 
           setSuggestions(results.slice(0, 8));
         } catch (error) {
-          console.error('Error fetching suggestions:', error);
+          logger.error('Error fetching suggestions:', error);
           
           // Final fallback: if everything fails and it's an airport search, use local data
           if (searchType === "airport") {
@@ -304,7 +305,7 @@ export const DestinationAutocomplete = ({
       onChange("Current Location");
       setShowSuggestions(false);
     } catch (error) {
-      console.error("Error getting location:", error);
+      logger.error("Error getting location:", error);
     } finally {
       setIsGettingLocation(false);
     }

--- a/src/components/search/FeaturedDealsCarousel.tsx
+++ b/src/components/search/FeaturedDealsCarousel.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Plane, Calendar, Percent } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 // Import destination images
 import tokyoImg from '@/assets/destinations/tokyo.jpg';
@@ -94,7 +95,7 @@ export function FeaturedDealsCarousel({ onDealSelect, origin = 'SYD' }: Featured
         });
 
         if (error) {
-          console.error('Error fetching featured deals:', error);
+          logger.error('Error fetching featured deals:', error);
           return;
         }
 
@@ -108,7 +109,7 @@ export function FeaturedDealsCarousel({ onDealSelect, origin = 'SYD' }: Featured
           setDeals(dealsData);
         }
       } catch (error) {
-        console.error('Error fetching featured deals:', error);
+        logger.error('Error fetching featured deals:', error);
       } finally {
         setLoading(false);
       }

--- a/src/components/search/FeaturedHotelDeals.tsx
+++ b/src/components/search/FeaturedHotelDeals.tsx
@@ -6,6 +6,7 @@ import { MapPin, Star, Percent, Calendar, Wifi, Car, Utensils, Loader2 } from 'l
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import logger from '@/utils/logger';
 
 interface FeaturedHotelDeal {
   id: string;
@@ -79,7 +80,7 @@ export function FeaturedHotelDeals({ onDealSelect }: FeaturedHotelDealsProps) {
             });
 
             if (error) {
-              console.warn(`Failed to fetch hotels for ${destination}:`, error);
+              logger.warn(`Failed to fetch hotels for ${destination}:`, error);
               continue;
             }
 
@@ -125,7 +126,7 @@ export function FeaturedHotelDeals({ onDealSelect }: FeaturedHotelDealsProps) {
               allDeals.push(...destinationDeals);
             }
           } catch (destError) {
-            console.warn(`Error fetching hotels for ${destination}:`, destError);
+            logger.warn(`Error fetching hotels for ${destination}:`, destError);
           }
         }
 
@@ -134,7 +135,7 @@ export function FeaturedHotelDeals({ onDealSelect }: FeaturedHotelDealsProps) {
         setDeals(shuffledDeals);
 
       } catch (error) {
-        console.error('Error fetching featured deals:', error);
+        logger.error('Error fetching featured deals:', error);
         toast.error('Unable to load featured deals');
       } finally {
         setLoading(false);

--- a/src/components/search/PopularHotelsSection.tsx
+++ b/src/components/search/PopularHotelsSection.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import logger from '@/utils/logger';
 
 interface PopularHotel {
   id: string;
@@ -60,7 +61,7 @@ export function PopularHotelsSection({ onHotelSelect }: PopularHotelsSectionProp
             });
 
             if (error) {
-              console.warn(`Failed to fetch hotels for ${destination}:`, error);
+              logger.warn(`Failed to fetch hotels for ${destination}:`, error);
               continue;
             }
 
@@ -82,7 +83,7 @@ export function PopularHotelsSection({ onHotelSelect }: PopularHotelsSectionProp
               allHotels.push(...destinationHotels);
             }
           } catch (destError) {
-            console.warn(`Error fetching hotels for ${destination}:`, destError);
+            logger.warn(`Error fetching hotels for ${destination}:`, destError);
           }
         }
 
@@ -91,7 +92,7 @@ export function PopularHotelsSection({ onHotelSelect }: PopularHotelsSectionProp
         setHotels(shuffledHotels);
 
       } catch (error) {
-        console.error('Error fetching popular hotels:', error);
+        logger.error('Error fetching popular hotels:', error);
         toast({
           title: 'Unable to load popular hotels',
           description: 'Please try again later',

--- a/src/components/search/PopularRoutesSection.tsx
+++ b/src/components/search/PopularRoutesSection.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Plane, TrendingUp } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 // Import destination images
 import tokyoImg from '@/assets/destinations/tokyo.jpg';
@@ -85,7 +86,7 @@ export function PopularRoutesSection({ onRouteSelect, origin = 'SYD' }: PopularR
         });
 
         if (error) {
-          console.error('Error fetching popular routes:', error);
+          logger.error('Error fetching popular routes:', error);
           return;
         }
 
@@ -93,7 +94,7 @@ export function PopularRoutesSection({ onRouteSelect, origin = 'SYD' }: PopularR
           setRoutes(data.data.inspiration);
         }
       } catch (error) {
-        console.error('Error fetching popular routes:', error);
+        logger.error('Error fetching popular routes:', error);
       } finally {
         setLoading(false);
       }

--- a/src/features/agenticBot/lib/agenticClient.ts
+++ b/src/features/agenticBot/lib/agenticClient.ts
@@ -1,4 +1,5 @@
 // Agentic Bot Client - Handles AI-powered travel planning and booking automation
+import logger from '@/utils/logger';
 
 interface AgenticTaskParams {
   userId?: string;
@@ -56,7 +57,7 @@ export const runAgenticTask = async (
 
     return data;
   } catch (error) {
-    console.error('Agentic Bot API Error:', error);
+    logger.error('Agentic Bot API Error:', error);
     
     // Fallback responses based on intent
     const fallbackResponses: Record<string, string> = {
@@ -92,7 +93,7 @@ export const getAgenticTaskStatus = async (userId: string): Promise<any[]> => {
 
     return await response.json();
   } catch (error) {
-    console.error('Failed to fetch agentic task status:', error);
+    logger.error('Failed to fetch agentic task status:', error);
     return [];
   }
 };
@@ -111,7 +112,7 @@ export const cancelAgenticTask = async (taskId: string): Promise<boolean> => {
 
     return response.ok;
   } catch (error) {
-    console.error('Failed to cancel agentic task:', error);
+    logger.error('Failed to cancel agentic task:', error);
     return false;
   }
 };
@@ -178,6 +179,6 @@ export const runAgenticTaskWithRetry = async (
     }
   }
 
-  console.error(`Agentic Bot failed after ${maxRetries} attempts:`, lastError);
+  logger.error(`Agentic Bot failed after ${maxRetries} attempts:`, lastError);
   throw lastError;
 };

--- a/src/features/auth/components/AdminLoginForm.tsx
+++ b/src/features/auth/components/AdminLoginForm.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../context/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { Shield, Mail, Lock } from 'lucide-react';
+import logger from "@/utils/logger";
 
 interface AdminLoginFormProps {
   onSwitchToRegular: () => void;
@@ -41,7 +42,7 @@ export const AdminLoginForm: React.FC<AdminLoginFormProps> = ({ onSwitchToRegula
       const { data: isAdmin, error: adminCheckError } = await supabase.rpc('get_admin_status');
 
       if (adminCheckError) {
-        console.error('Admin status check failed:', adminCheckError);
+        logger.error('Admin status check failed:', adminCheckError);
         await supabase.auth.signOut();
         toast({
           title: "Security Error",

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -7,6 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import { Mail, Lock, User, Github } from 'lucide-react';
+import logger from "@/utils/logger";
 
 interface SignUpFormProps {
   onSwitchToLogin: () => void;
@@ -85,7 +86,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({ onSwitchToLogin }) => {
         }
       }
     } catch (error) {
-      console.error('Signup error:', error);
+      logger.error('Signup error:', error);
       toast({
         title: "Error",
         description: "An unexpected error occurred",

--- a/src/features/auth/context/AuthContext.tsx
+++ b/src/features/auth/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 interface AuthContextType {
   user: User | null;
@@ -52,7 +53,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setSession(session);
         setUser(session?.user ?? null);
       } catch (e) {
-        console.error('Auth init error:', e);
+        logger.error('Auth init error:', e);
       } finally {
         if (isMounted) setLoading(false);
       }
@@ -87,7 +88,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       
       return { data, error };
     } catch (err) {
-      console.error('AuthContext: Signup error:', err);
+      logger.error('AuthContext: Signup error:', err);
       return { data: null, error: err as any };
     }
   };

--- a/src/features/booking/components/HotelGuestForm.tsx
+++ b/src/features/booking/components/HotelGuestForm.tsx
@@ -14,6 +14,7 @@ import { Sparkles, User } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { autofillService } from "@/lib/autofillService";
+import logger from "@/utils/logger";
 
 const HotelGuestSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -52,7 +53,7 @@ export default function HotelGuestForm({ onChange, initial }: HotelGuestFormProp
         return { ...parsed, ...initial }; // initial props take precedence
       }
     } catch (error) {
-      console.error('Error loading saved guest data:', error);
+      logger.error('Error loading saved guest data:', error);
     }
     return {
       title: "",

--- a/src/features/booking/components/PassengerDetailsForm.tsx
+++ b/src/features/booking/components/PassengerDetailsForm.tsx
@@ -12,6 +12,7 @@ import { Sparkles, User } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { autofillService } from "@/lib/autofillService";
+import logger from "@/utils/logger";
 
 // Schema for hotel guest details
 const GuestSchema = z.object({
@@ -64,7 +65,7 @@ export const PassengerDetailsForm: React.FC<PassengerDetailsFormProps> = ({
         return { ...parsed, ...initial }; // initial props take precedence
       }
     } catch (error) {
-      console.error('Error loading saved passenger data:', error);
+      logger.error('Error loading saved passenger data:', error);
     }
     return {
       title: "MR",

--- a/src/features/booking/hooks/useActivityBooking.ts
+++ b/src/features/booking/hooks/useActivityBooking.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useAuth } from "@/features/auth/context/AuthContext";
+import logger from "@/utils/logger";
 
 interface ActivityBookingParams {
   activityId: string;
@@ -103,7 +104,7 @@ export const useActivityBooking = () => {
       });
 
       if (paymentError) {
-        console.error('Payment creation error:', paymentError);
+        logger.error('Payment creation error:', paymentError);
         toast.error('Booking created but payment setup failed. Please contact support.');
       }
 
@@ -120,7 +121,7 @@ export const useActivityBooking = () => {
       };
 
     } catch (error) {
-      console.error('Activity booking error:', error);
+      logger.error('Activity booking error:', error);
       toast.error(error instanceof Error ? error.message : 'Activity booking failed');
       
       return {

--- a/src/features/booking/hooks/useBookingPayment.ts
+++ b/src/features/booking/hooks/useBookingPayment.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import logger from "@/utils/logger";
 
 interface BookingPaymentParams {
   bookingType: 'flight' | 'hotel' | 'activity' | 'package';
@@ -71,7 +72,7 @@ export const useBookingPayment = () => {
       return data;
 
     } catch (error) {
-      console.error('Booking payment error:', error);
+      logger.error('Booking payment error:', error);
       
       const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
       

--- a/src/features/booking/hooks/useFlightBooking.ts
+++ b/src/features/booking/hooks/useFlightBooking.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useAuth } from "@/features/auth/context/AuthContext";
+import logger from "@/utils/logger";
 
 interface PassengerDetails {
   firstName: string;
@@ -135,7 +136,7 @@ export const useFlightBooking = () => {
         .single();
 
       if (supabaseError) {
-        console.error('Supabase booking error:', supabaseError);
+        logger.error('Supabase booking error:', supabaseError);
         // Don't fail here - we have the Amadeus booking
         toast.error('Booking saved to external system but may not appear in dashboard immediately');
       }
@@ -156,7 +157,7 @@ export const useFlightBooking = () => {
       });
 
       if (paymentError) {
-        console.error('Payment creation error:', paymentError);
+        logger.error('Payment creation error:', paymentError);
         // Booking exists but payment failed
         toast.error('Booking created but payment setup failed. Please contact support.');
       }
@@ -171,7 +172,7 @@ export const useFlightBooking = () => {
       };
 
     } catch (error) {
-      console.error('Flight booking error:', error);
+      logger.error('Flight booking error:', error);
       toast.error(error instanceof Error ? error.message : 'Flight booking failed');
       
       return {

--- a/src/features/booking/hooks/useHotelBooking.ts
+++ b/src/features/booking/hooks/useHotelBooking.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useAuth } from "@/features/auth/context/AuthContext";
+import logger from "@/utils/logger";
 
 interface HotelBookingParams {
   hotelOfferId: string;
@@ -120,7 +121,7 @@ export const useHotelBooking = () => {
       }
 
     } catch (error) {
-      console.error('Hotel booking error:', error);
+      logger.error('Hotel booking error:', error);
       toast.error(error instanceof Error ? error.message : 'Hotel booking failed');
       
       return {

--- a/src/features/bookingEnhancements/components/FavoritesSidebar.tsx
+++ b/src/features/bookingEnhancements/components/FavoritesSidebar.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast";
 import { fetchUserFavorites, toggleFavorite } from "@/lib/bookingDataClient";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { Heart, MapPin, Plane, Hotel, Camera, Trash2 } from "lucide-react";
+import logger from "@/utils/logger";
 
 interface Favorite {
   id: string;
@@ -35,7 +36,7 @@ export default function FavoritesSidebar() {
       const data = await fetchUserFavorites(user.id);
       setFavorites(data);
     } catch (error) {
-      console.error('Error loading favorites:', error);
+      logger.error('Error loading favorites:', error);
       toast({
         title: "Error",
         description: "Failed to load favorites.",

--- a/src/features/bookingEnhancements/components/LocalTipsPanel.tsx
+++ b/src/features/bookingEnhancements/components/LocalTipsPanel.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { fetchLocalInsights } from "@/lib/bookingDataClient";
 import { MapPin, Star, Utensils, Car, Camera, Info } from "lucide-react";
+import logger from "@/utils/logger";
 interface LocalInsight {
   id: string;
   location_id: string;
@@ -32,7 +33,7 @@ export default function LocalTipsPanel({
       const data = await fetchLocalInsights(locationId);
       setInsights(data);
     } catch (error) {
-      console.error('Error loading local insights:', error);
+      logger.error('Error loading local insights:', error);
     } finally {
       setLoading(false);
     }

--- a/src/features/bookingEnhancements/components/OffersWidget.tsx
+++ b/src/features/bookingEnhancements/components/OffersWidget.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { listDynamicOffers } from "@/lib/bookingDataClient";
 import { Tag, Clock, Zap } from "lucide-react";
+import logger from "@/utils/logger";
 interface DynamicOffer {
   id: string;
   route: string;
@@ -37,7 +38,7 @@ export default function OffersWidget({
       });
       setOffers(data);
     } catch (error) {
-      console.error('Error loading offers:', error);
+      logger.error('Error loading offers:', error);
     } finally {
       setLoading(false);
     }

--- a/src/features/bookingEnhancements/components/OneClickBooking.tsx
+++ b/src/features/bookingEnhancements/components/OneClickBooking.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/hooks/use-toast";
 import { fetchUserPreferences, saveUserPreferences, fetchPassportInfo, fetchPaymentMethods } from "@/lib/bookingDataClient";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { Calendar, MapPin, CreditCard, CheckCircle, Zap, Users } from "lucide-react";
+import logger from "@/utils/logger";
 
 interface BookingFormData {
   destination: string;
@@ -72,7 +73,7 @@ export default function OneClickBooking({ bookingData, onBookingComplete }: OneC
       setCanOneClick(hasVerifiedPassport && hasPaymentMethod);
 
     } catch (error) {
-      console.error('Error loading user data:', error);
+      logger.error('Error loading user data:', error);
     }
   };
 
@@ -111,7 +112,7 @@ export default function OneClickBooking({ bookingData, onBookingComplete }: OneC
       onBookingComplete?.(mockBookingId);
 
     } catch (error) {
-      console.error('Booking error:', error);
+      logger.error('Booking error:', error);
       toast({
         title: "Booking failed",
         description: "Something went wrong. Please try again.",

--- a/src/features/bookingEnhancements/components/PassportUploader.tsx
+++ b/src/features/bookingEnhancements/components/PassportUploader.tsx
@@ -9,6 +9,7 @@ import { savePassportInfo } from "@/lib/bookingDataClient";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { Upload, FileText, CheckCircle, AlertCircle, Camera } from "lucide-react";
+import logger from "@/utils/logger";
 
 const countries = [
   "Australia", "United States", "United Kingdom", "Canada", "Germany", 
@@ -73,7 +74,7 @@ export default function PassportUploader() {
       await handleValidatePassport(mockUrl);
       
     } catch (error) {
-      console.error('Upload error:', error);
+      logger.error('Upload error:', error);
       toast({
         title: "Upload failed",
         description: "Failed to upload passport image. Please try again.",
@@ -125,7 +126,7 @@ export default function PassportUploader() {
         });
       }
     } catch (error) {
-      console.error('Validation error:', error);
+      logger.error('Validation error:', error);
       toast({
         title: "Validation error",
         description: "Failed to validate passport. Please try again.",
@@ -157,7 +158,7 @@ export default function PassportUploader() {
         description: "Your passport information has been saved successfully.",
       });
     } catch (error) {
-      console.error('Save error:', error);
+      logger.error('Save error:', error);
       toast({
         title: "Save failed",
         description: "Failed to save passport information.",

--- a/src/features/bookingEnhancements/components/PaymentVault.tsx
+++ b/src/features/bookingEnhancements/components/PaymentVault.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast";
 import { fetchPaymentMethods } from "@/lib/bookingDataClient";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CreditCard, Plus, Trash2, Star } from "lucide-react";
+import logger from "@/utils/logger";
 
 interface PaymentMethod {
   id: string;
@@ -38,7 +39,7 @@ export default function PaymentVault() {
       const methods = await fetchPaymentMethods(user.id);
       setPaymentMethods(methods);
     } catch (error) {
-      console.error('Error loading payment methods:', error);
+      logger.error('Error loading payment methods:', error);
       toast({
         title: "Error",
         description: "Failed to load payment methods.",

--- a/src/features/bookingEnhancements/components/UserPreferencesForm.tsx
+++ b/src/features/bookingEnhancements/components/UserPreferencesForm.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/hooks/use-toast";
 import { fetchUserPreferences, saveUserPreferences } from "@/lib/bookingDataClient";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { Plane, Hotel, Utensils, Globe, DollarSign } from "lucide-react";
+import logger from "@/utils/logger";
 
 const airlines = ["Qantas", "Virgin Australia", "Jetstar", "Emirates", "Singapore Airlines"];
 const mealOptions = ["Vegetarian", "Vegan", "Gluten-free", "Kosher", "Halal"];
@@ -48,7 +49,7 @@ export default function UserPreferencesForm() {
         });
       }
     } catch (error) {
-      console.error('Error loading preferences:', error);
+      logger.error('Error loading preferences:', error);
     }
   };
 

--- a/src/features/makuBot/components/ChatWidget.tsx
+++ b/src/features/makuBot/components/ChatWidget.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import MessageBubble from './MessageBubble';
 import { sendToMakuBot } from '../lib/makuBotClient';
+import logger from "@/utils/logger";
 
 interface Message {
   id: string;
@@ -46,7 +47,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ userVertical = 'Solo' }) => {
         const parsed = JSON.parse(savedMessages);
         setMessages(parsed);
       } catch (error) {
-        console.error('Failed to load saved messages:', error);
+        logger.error('Failed to load saved messages:', error);
       }
     }
   }, []);
@@ -87,7 +88,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ userVertical = 'Solo' }) => {
 
       setMessages(prev => [...prev, botMessage]);
     } catch (error) {
-      console.error('Failed to get bot response:', error);
+      logger.error('Failed to get bot response:', error);
       const errorMessage: Message = {
         id: (Date.now() + 1).toString(),
         text: "Sorry, I'm having trouble connecting right now. Please try again!",

--- a/src/features/makuBot/lib/makuBotClient.ts
+++ b/src/features/makuBot/lib/makuBotClient.ts
@@ -1,4 +1,5 @@
 // TODO: Replace with your Supabase edge function URL
+import logger from '@/utils/logger';
 const MAKU_BOT_API_URL = '/api/maku-bot'; // This will be a Supabase Edge Function
 
 interface MakuBotContext {
@@ -53,7 +54,7 @@ export const sendToMakuBot = async (
 
     return data.reply || 'Sorry, I couldn\'t process that request.';
   } catch (error) {
-    console.error('MakuBot API Error:', error);
+    logger.error('MakuBot API Error:', error);
     
     // Fallback responses based on context
     const fallbackResponses = {
@@ -91,6 +92,6 @@ export const sendToMakuBotWithRetry = async (
     }
   }
 
-  console.error(`MakuBot failed after ${maxRetries} attempts:`, lastError);
+  logger.error(`MakuBot failed after ${maxRetries} attempts:`, lastError);
   throw lastError;
 };

--- a/src/features/search/hooks/useActivitySearch.ts
+++ b/src/features/search/hooks/useActivitySearch.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 // Import activity images
 import bridgeClimbImg from "@/assets/activity-bridge-climb.jpg";
@@ -87,7 +88,7 @@ export const useActivitySearch = (criteria: ActivitySearchCriteria) => {
           setError("No activities found for your search criteria");
         }
       } catch (err) {
-        console.error("Activity search error:", err);
+        logger.error("Activity search error:", err);
         setError(err instanceof Error ? err.message : "Failed to search activities");
         toast.error("Activity search failed. Please try different search criteria.");
         setActivities([]);

--- a/src/features/search/hooks/useCarSearch.ts
+++ b/src/features/search/hooks/useCarSearch.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 interface CarSearchCriteria {
   pickUpLocation: string;
@@ -106,7 +107,7 @@ export const useCarSearch = (criteria: CarSearchCriteria) => {
           setError("No cars available for your search criteria. Try different dates or locations.");
         }
       } catch (err) {
-        console.error("Car search error:", err);
+        logger.error("Car search error:", err);
         setError(err instanceof Error ? err.message : "Failed to search cars");
         toast.error("Failed to search cars. Please try different search criteria.");
         setCars([]);

--- a/src/features/search/hooks/useFlightSearch.ts
+++ b/src/features/search/hooks/useFlightSearch.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { detectFlightCurrency } from "@/lib/currencyDetection";
+import logger from '@/utils/logger';
 
 interface FlightSearchCriteria {
   origin: string;
@@ -299,7 +300,7 @@ export const useFlightSearch = (criteria: FlightSearchCriteria | null) => {
           }
         }
       } catch (err) {
-        console.error("Flight search error:", err);
+        logger.error("Flight search error:", err);
         setError(err instanceof Error ? err.message : "Failed to search flights");
         toast.error("Flight search failed. Please try different search criteria.");
         setFlights([]);

--- a/src/features/search/hooks/useHotelSearch.ts
+++ b/src/features/search/hooks/useHotelSearch.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useReducer, useMemo, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 // Import hotel images
 import shangriLaImg from "@/assets/hotel-shangri-la.jpg";
@@ -170,7 +171,7 @@ export const useHotelSearch = (criteria: HotelSearchCriteria | null) => {
 
       // Enhanced error handling with specific user-friendly messages
       if (functionError) {
-        console.error("❌ Hotel search function error:", functionError);
+        logger.error("❌ Hotel search function error:", functionError);
         
         // Provide specific error messages based on error type with actionable guidance
         let userMessage = "Hotel search failed. Please try again.";
@@ -260,7 +261,7 @@ export const useHotelSearch = (criteria: HotelSearchCriteria | null) => {
         }
       } else if (data?.systemError) {
         // PHASE 1: Handle system-level errors (circuit breaker, service unavailable)
-        console.error("🚨 System error:", data.technicalError);
+        logger.error("🚨 System error:", data.technicalError);
         
         let userMessage = "Hotel search is temporarily unavailable. Please try again in a few minutes.";
         if (data.retryAfter) {
@@ -280,7 +281,7 @@ export const useHotelSearch = (criteria: HotelSearchCriteria | null) => {
     } catch (err: any) {
       if (signal.aborted) return;
       
-      console.error("Hotel search error:", err);
+      logger.error("Hotel search error:", err);
       
       let errorMessage = "Failed to search hotels. Please try again.";
       let systemError = false;

--- a/src/hooks/useAmadeusSearch.ts
+++ b/src/hooks/useAmadeusSearch.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import type {
+import logger from "@/utils/logger";
   FlightSearchParams,
   HotelSearchParams,
   TransferSearchParams,
@@ -57,7 +58,7 @@ export const useFlightSearch = () => {
       }
 
     } catch (error) {
-      console.error('Flight search error:', error);
+      logger.error('Flight search error:', error);
       setState({
         data: null,
         loading: false,
@@ -114,7 +115,7 @@ export const useHotelSearch = () => {
       }
 
     } catch (error) {
-      console.error('Hotel search error:', error);
+      logger.error('Hotel search error:', error);
       setState({
         data: null,
         loading: false,
@@ -171,7 +172,7 @@ export const useTransferSearch = () => {
       }
 
     } catch (error) {
-      console.error('Transfer search error:', error);
+      logger.error('Transfer search error:', error);
       setState({
         data: null,
         loading: false,
@@ -228,7 +229,7 @@ export const useActivitySearch = () => {
       }
 
     } catch (error) {
-      console.error('Activity search error:', error);
+      logger.error('Activity search error:', error);
       setState({
         data: null,
         loading: false,

--- a/src/hooks/useHotelOffers.ts
+++ b/src/hooks/useHotelOffers.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import logger from "@/utils/logger";
 
 interface HotelOffersParams {
   hotelId: string;
@@ -76,7 +77,7 @@ export const useHotelOffers = (): UseHotelOffersResult => {
       });
 
       if (functionError) {
-        console.error('Hotel offers function error:', functionError);
+        logger.error('Hotel offers function error:', functionError);
         throw new Error(functionError.message || 'Failed to fetch hotel offers');
       }
 
@@ -94,7 +95,7 @@ export const useHotelOffers = (): UseHotelOffersResult => {
         throw new Error(data?.error || 'Failed to fetch hotel offers');
       }
     } catch (err: any) {
-      console.error('Hotel offers error:', err);
+      logger.error('Hotel offers error:', err);
       const errorMessage = err.message || 'Failed to fetch hotel offers';
       setError(errorMessage);
       toast.error(errorMessage);

--- a/src/hooks/useHotelPhotos.ts
+++ b/src/hooks/useHotelPhotos.ts
@@ -1,6 +1,7 @@
 
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import logger from '@/utils/logger';
 
 interface HotelPhoto {
   url: string;
@@ -34,7 +35,7 @@ export const useHotelPhotos = (): UseHotelPhotosResult => {
       });
 
       if (functionError) {
-        console.error('Hotel photos function error:', functionError);
+        logger.error('Hotel photos function error:', functionError);
         throw new Error(functionError.message || 'Failed to fetch hotel photos');
       }
 
@@ -45,7 +46,7 @@ export const useHotelPhotos = (): UseHotelPhotosResult => {
         throw new Error(data?.error || 'Failed to fetch hotel photos');
       }
     } catch (err: any) {
-      console.error('Hotel photos error:', err);
+      logger.error('Hotel photos error:', err);
       const errorMessage = err.message || 'Failed to fetch hotel photos';
       setError(errorMessage);
       setPhotos([]);

--- a/src/lib/autofillService.ts
+++ b/src/lib/autofillService.ts
@@ -1,4 +1,5 @@
 import { fetchUserPreferences, fetchPassportInfo } from './bookingDataClient';
+import logger from "@/utils/logger";
 
 // Production app - mock data generators removed
 // All user input is now handled through real user data or empty forms
@@ -17,7 +18,7 @@ export const loadUserStoredData = async (userId: string) => {
       hasStoredData: !!(preferences || passport)
     };
   } catch (error) {
-    console.error('Error loading user stored data:', error);
+    logger.error('Error loading user stored data:', error);
     return {
       preferences: {},
       passport: {},

--- a/src/lib/otaDataClient.ts
+++ b/src/lib/otaDataClient.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 // Reviews & Ratings API
 export const reviewsAPI = {
@@ -288,7 +289,7 @@ export const activityAPI = {
         ...activity
       });
     
-    if (error) console.warn('Activity logging failed:', error);
+    if (error) logger.warn('Activity logging failed:', error);
   },
 
   async fetchRecentActivity(itemType?: string, limit = 50) {

--- a/src/pages/AdminAuth.tsx
+++ b/src/pages/AdminAuth.tsx
@@ -4,6 +4,7 @@ import { AdminLoginForm } from '@/features/auth/components/AdminLoginForm';
 import { LoginForm } from '@/features/auth/components/LoginForm';
 import { Navigate, useLocation } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 const AdminAuth = () => {
   const { user, loading } = useAuth();
@@ -20,7 +21,7 @@ const AdminAuth = () => {
       if (user) {
         const { data: isAdmin, error } = await supabase.rpc('get_admin_status');
         if (error) {
-          console.error('Admin status check failed:', error);
+          logger.error('Admin status check failed:', error);
           setIsAdmin(false);
         } else {
           setIsAdmin(!!isAdmin);

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { 
+import logger from "@/utils/logger";
   Users, DollarSign, Settings, Shield, TrendingUp, 
   Building, Plane, MapPin, CheckCircle, XCircle, 
   Eye, Edit, AlertTriangle, Filter, Search,
@@ -87,7 +88,7 @@ const AdminDashboard = () => {
       });
 
     } catch (error) {
-      console.error('Error fetching dashboard data:', error);
+      logger.error('Error fetching dashboard data:', error);
       toast({
         title: "Error",
         description: "Failed to load dashboard data",

--- a/src/pages/BookingConfirmation.tsx
+++ b/src/pages/BookingConfirmation.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, Loader2 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
+import logger from "@/utils/logger";
 
 interface BookingData {
   id: string;
@@ -77,7 +78,7 @@ export default function BookingConfirmation() {
 
         throw new Error('Booking not found');
       } catch (err: any) {
-        console.error('Booking confirmation error:', err);
+        logger.error('Booking confirmation error:', err);
         setError(err.message || 'Failed to load booking details');
       } finally {
         setLoading(false);

--- a/src/pages/BookingDetails.tsx
+++ b/src/pages/BookingDetails.tsx
@@ -11,6 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { ArrowLeft, Download, Calendar, Users, DollarSign, CreditCard, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+import logger from "@/utils/logger";
 
 interface BookingDetailsData {
   id: string;
@@ -69,7 +70,7 @@ const BookingDetailsInner: React.FC = () => {
       }
       setBooking(foundBooking);
     } catch (error) {
-      console.error('Error fetching booking details:', error);
+      logger.error('Error fetching booking details:', error);
       toast({
         title: "Error",
         description: "Failed to load booking details. Please try again.",

--- a/src/pages/BookingExtras.tsx
+++ b/src/pages/BookingExtras.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { ChevronLeft, Plus, Minus } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 type Addon = {
   id: string; 
@@ -48,13 +49,13 @@ export default function BookingExtras() {
           .eq("active", true);
           
         if (error) {
-          console.error('Error loading addons:', error);
+          logger.error('Error loading addons:', error);
           toast.error('Failed to load hotel extras');
         } else {
           setAddons(data as Addon[]);
         }
       } catch (err) {
-        console.error('Addons loading error:', err);
+        logger.error('Addons loading error:', err);
         toast.error('Failed to load hotel extras');
       } finally {
         setLoading(false);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Eye, X, Calendar, Users, DollarSign, Loader2, Zap, TrendingUp, Activity, BarChart3, RefreshCw } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import logger from "@/utils/logger";
 
 import { SmartAnalytics } from '@/components/dashboard/SmartAnalytics';
 import { RealTimeFeeds } from '@/components/dashboard/RealTimeFeeds';
@@ -74,7 +75,7 @@ export const Dashboard: React.FC = () => {
       const { data, error } = await supabase.rpc('get_user_bookings');
       
       if (error) {
-        console.error('Error fetching bookings:', error);
+        logger.error('Error fetching bookings:', error);
         toast({
           title: "Error",
           description: "Failed to load your bookings. Please try again.",
@@ -111,7 +112,7 @@ export const Dashboard: React.FC = () => {
       }
       
     } catch (err) {
-      console.error('Fetch bookings exception:', err);
+      logger.error('Fetch bookings exception:', err);
       toast({
         title: "Error",
         description: "Failed to load your bookings. Please try again.",
@@ -144,7 +145,7 @@ export const Dashboard: React.FC = () => {
         throw new Error(result.message);
       }
     } catch (error) {
-      console.error('Error cancelling booking:', error);
+      logger.error('Error cancelling booking:', error);
       toast({
         title: "Error",
         description: "Failed to cancel booking. Please try again.",

--- a/src/pages/FlightBookingReview.tsx
+++ b/src/pages/FlightBookingReview.tsx
@@ -8,6 +8,7 @@ import Navbar from "@/components/Navbar";
 import { FlightBookingProgress } from "@/components/flight/FlightBookingProgress";
 import { useCurrency } from "@/features/currency/CurrencyProvider";
 import { useToast } from "@/hooks/use-toast";
+import logger from "@/utils/logger";
 
 interface FlightDetails {
   id: string;
@@ -52,7 +53,7 @@ const FlightBookingReview = () => {
         const outbound = JSON.parse(storedOutbound);
         setOutboundFlight(outbound);
       } catch (error) {
-        console.error('Error parsing outbound flight:', error);
+        logger.error('Error parsing outbound flight:', error);
       }
     }
 
@@ -61,7 +62,7 @@ const FlightBookingReview = () => {
         const inbound = JSON.parse(storedInbound);
         setInboundFlight(inbound);
       } catch (error) {
-        console.error('Error parsing inbound flight:', error);
+        logger.error('Error parsing inbound flight:', error);
       }
     }
 
@@ -75,7 +76,7 @@ const FlightBookingReview = () => {
           return total + (flight.fare?.price || 0);
         }, 0);
       } catch (error) {
-        console.error('Error parsing multi-city flights:', error);
+        logger.error('Error parsing multi-city flights:', error);
       }
     } else {
       const outboundPrice = outboundFlight?.price || 0;

--- a/src/pages/FlightCheckout.tsx
+++ b/src/pages/FlightCheckout.tsx
@@ -9,6 +9,7 @@ import { PassengerDetailsForm, PassengerFormData } from "@/features/booking/comp
 import { FlightBookingSummary } from "@/features/booking/components/FlightBookingSummary";
 import { useToast } from "@/hooks/use-toast";
 import { CurrencyDisplay } from "@/components/CurrencyDisplay";
+import logger from "@/utils/logger";
 
 const FlightCheckout = () => {
   const [passengerValid, setPassengerValid] = useState(false);
@@ -71,7 +72,7 @@ const FlightCheckout = () => {
         console.log('Saved passenger info to session storage');
       }
     } catch (e) {
-      console.error('Session storage error:', e);
+      logger.error('Session storage error:', e);
     }
     
     const search = typeof window !== 'undefined' ? window.location.search : '';

--- a/src/pages/GiftCards.tsx
+++ b/src/pages/GiftCards.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import Navbar from "@/components/Navbar";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
+import logger from '@/utils/logger';
 
 // Import travel images
 import heroMaldives from "@/assets/hero-maldives.jpg";
@@ -134,7 +135,7 @@ const GiftCardsPage = () => {
         throw new Error(data.error || "Failed to create gift card");
       }
     } catch (error: any) {
-      console.error("Gift card purchase error:", error);
+      logger.error("Gift card purchase error:", error);
       toast({
         title: "Purchase Failed",
         description: error.message || "Something went wrong. Please try again.",

--- a/src/pages/HotelCheckout.tsx
+++ b/src/pages/HotelCheckout.tsx
@@ -9,6 +9,7 @@ import Navbar from "@/components/Navbar";
 import HotelGuestForm, { HotelGuestFormData } from "@/features/booking/components/HotelGuestForm";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import logger from "@/utils/logger";
 
 // Load Stripe
 const stripePromise = loadStripe('pk_test_51QXYwPILlBrPBZqYWJSr9jbQ2zLMlVHwBb7LQI8c7QJ8x9eLqShZ8N2C8p4lJaW1qZQrNxGO2YI9QwV3O8cM2YrM00lV2XFO6W');
@@ -61,7 +62,7 @@ function CheckoutInner() {
         });
 
         if (error) {
-          console.error('Booking creation error:', error);
+          logger.error('Booking creation error:', error);
           throw error;
         }
 
@@ -81,7 +82,7 @@ function CheckoutInner() {
           throw new Error(data?.error || 'Failed to create booking');
         }
       } catch (err: any) {
-        console.error('Error creating booking:', err);
+        logger.error('Error creating booking:', err);
         toast({
           title: "Booking error",
           description: err.message || 'Failed to prepare booking',
@@ -123,7 +124,7 @@ function CheckoutInner() {
       });
 
       if (error) {
-        console.error('Payment error:', error);
+        logger.error('Payment error:', error);
         toast({
           title: "Payment failed",
           description: error.message,
@@ -131,7 +132,7 @@ function CheckoutInner() {
         });
       }
     } catch (err) {
-      console.error('Payment processing error:', err);
+      logger.error('Payment processing error:', err);
       toast({
         title: "Payment error", 
         description: "Failed to process payment",

--- a/src/pages/HotelDetails.tsx
+++ b/src/pages/HotelDetails.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, MapPin, Star, Wifi, Car, Utensils, Waves } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import logger from "@/utils/logger";
 
 type RoomOffer = {
   id: string;
@@ -86,7 +87,7 @@ export const HotelDetails = () => {
           throw new Error(data?.error || 'Failed to fetch hotel details');
         }
       } catch (err: any) {
-        console.error('Hotel details error:', err);
+        logger.error('Hotel details error:', err);
         const errorMessage = err.message || 'Failed to fetch hotel details';
         setError(errorMessage);
         toast.error(errorMessage);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,12 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import logger from "@/utils/logger";
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
+    logger.error(
       "404 Error: User attempted to access non-existent route:",
       location.pathname
     );

--- a/src/pages/PartnerAuth.tsx
+++ b/src/pages/PartnerAuth.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '@/features/auth/context/AuthContext';
 import { useToast } from '@/components/ui/use-toast';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 const PartnerAuth = () => {
   const { signUp } = useAuth();
@@ -108,7 +109,7 @@ const PartnerAuth = () => {
           });
 
         if (profileError) {
-          console.error('Profile creation error:', profileError);
+          logger.error('Profile creation error:', profileError);
         }
 
         // Initiate payment flow

--- a/src/pages/PaymentSetup.tsx
+++ b/src/pages/PaymentSetup.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
 import { CreditCard, Shield, Clock } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 const PaymentForm = () => {
   const stripe = useStripe();
@@ -51,7 +52,7 @@ const PaymentForm = () => {
       }
 
       if (result.error) {
-        console.error('Payment error:', result.error);
+        logger.error('Payment error:', result.error);
         toast({
           title: "Payment Error",
           description: result.error.message,
@@ -65,7 +66,7 @@ const PaymentForm = () => {
         });
       }
     } catch (error) {
-      console.error('Payment submission error:', error);
+      logger.error('Payment submission error:', error);
       toast({
         title: "Error",
         description: "An unexpected error occurred",
@@ -164,7 +165,7 @@ const PaymentSetup = () => {
         const { data, error } = await supabase.functions.invoke('get-stripe-publishable-key');
         
         if (error) {
-          console.error('Error fetching Stripe key:', error);
+          logger.error('Error fetching Stripe key:', error);
           toast({
             title: "Configuration Error",
             description: "Unable to load payment configuration. Please try again.",
@@ -185,7 +186,7 @@ const PaymentSetup = () => {
           });
         }
       } catch (error) {
-        console.error('Error loading Stripe:', error);
+        logger.error('Error loading Stripe:', error);
         toast({
           title: "Error",
           description: "Failed to initialize payment system.",

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
+import logger from "@/utils/logger";
 
 const PaymentSuccess = () => {
   const [searchParams] = useSearchParams();
@@ -47,7 +48,7 @@ const PaymentSuccess = () => {
       });
 
     } catch (error) {
-      console.error('Payment verification error:', error);
+      logger.error('Payment verification error:', error);
       toast({
         title: "Verification Error",
         description: "Unable to verify payment status",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,5 @@
+const logger = {
+  error: (...args: unknown[]) => console.error(...args),
+  warn: (...args: unknown[]) => console.warn(...args),
+};
+export default logger;


### PR DESCRIPTION
## Summary
- add centralized logger utility
- replace console.error and console.warn with logger.error and logger.warn across src

## Testing
- `npm run lint` *(fails: Unexpected any in types and require import warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a702bd094c83249514d3a9f127647b