### PR TITLE
feat: type booking payment flow

### DIFF
--- a/src/features/booking/hooks/useBookingPayment.ts
+++ b/src/features/booking/hooks/useBookingPayment.ts
@@ -1,21 +1,7 @@
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-
-interface BookingPaymentParams {
-  bookingType: 'flight' | 'hotel' | 'activity' | 'package';
-  bookingData: any;
-  amount: number;
-  currency?: string;
-  customerInfo: {
-    email: string;
-    firstName: string;
-    lastName: string;
-    phone?: string;
-  };
-  paymentMethod?: 'card' | 'fund' | 'split';
-  fundAmount?: number;
-}
+import type { BookingPaymentParams } from '@/types/booking';
 
 interface BookingPaymentResult {
   success: boolean;

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -1,0 +1,18 @@
+export interface BookingPayload {
+  [key: string]: unknown;
+}
+
+export interface BookingPaymentParams {
+  bookingType: 'flight' | 'hotel' | 'activity' | 'package';
+  bookingData: BookingPayload;
+  amount: number;
+  currency?: string;
+  customerInfo: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    phone?: string;
+  };
+  paymentMethod?: 'card' | 'fund' | 'split';
+  fundAmount?: number;
+}

--- a/supabase/functions/create-card-payment-intent/index.ts
+++ b/supabase/functions/create-card-payment-intent/index.ts
@@ -1,23 +1,11 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import type { BookingPaymentParams } from "../../../src/types/booking.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
-
-type BookingPaymentParams = {
-  bookingType: 'flight' | 'hotel' | 'activity' | 'package';
-  bookingData: any;
-  amount: number;
-  currency?: string;
-  customerInfo: {
-    email: string;
-    firstName: string;
-    lastName: string;
-    phone?: string;
-  };
 };
 
 serve(async (req) => {
@@ -26,8 +14,8 @@ serve(async (req) => {
   }
 
   try {
-    const body: BookingPaymentParams = await req.json();
-    const { bookingType, bookingData, amount, currency, customerInfo } = (body as any) ?? {};
+    const body = (await req.json()) as BookingPaymentParams;
+    const { bookingType, bookingData, amount, currency, customerInfo } = body;
     console.log('create-card-payment-intent init', {
       bookingType,
       amount,


### PR DESCRIPTION
## Summary
- centralize booking payment types and reference BookingPayload
- replace loose booking payment types with BookingPayload usage in card intent function and hook

## Testing
- `npm test` *(fails: Only URLs with a scheme in: file and data are supported by the default ESM loader)*
- `npm run lint` *(fails: Unexpected any and require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a70617157083249740c445d99b0fea