### PR TITLE
feat: improve automated cleanup tracking

### DIFF
--- a/supabase/functions/automated-cleanup-scheduler/index.ts
+++ b/supabase/functions/automated-cleanup-scheduler/index.ts
@@ -40,10 +40,9 @@ serve(async (req) => {
       logger.info('No recent cleanup found, triggering cleanup', { correlationId })
       
       const { data: cleanupResult, error: cleanupError } = await supabaseClient.functions.invoke('fix-stuck-bookings', {
-        body: { 
-          isAutomated: true,
-          correlationId,
-          timeoutMinutes: 10
+        body: {
+          automated: true,
+          timeout_minutes: 10
         }
       })
 
@@ -69,6 +68,13 @@ serve(async (req) => {
             headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
           }
         )
+      }
+
+      if (cleanupResult?.triggered_by !== 'automated') {
+        logger.error('Cleanup function returned unexpected trigger source', {
+          correlationId,
+          triggeredBy: cleanupResult?.triggered_by
+        })
       }
 
       logger.info('Cleanup triggered successfully', { correlationId, result: cleanupResult })

--- a/supabase/functions/fix-stuck-bookings/index.test.ts
+++ b/supabase/functions/fix-stuck-bookings/index.test.ts
@@ -1,0 +1,44 @@
+import { handler } from "./index.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: ${actual} !== ${expected}`);
+  }
+}
+
+Deno.test("automated cleanup logs trigger source", async () => {
+  const inserts: any[] = [];
+  const supabaseStub = {
+    from: (table: string) => {
+      if (table === 'bookings') {
+        return {
+          select: () => ({
+            eq: () => ({
+              lt: () => Promise.resolve({ data: [], error: null })
+            })
+          })
+        };
+      }
+      if (table === 'cleanup_audit') {
+        return {
+          insert: (data: any) => {
+            inserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    }
+  } as any;
+
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ automated: true })
+  });
+
+  const res = await handler(req, supabaseStub, {});
+  const data = await res.json();
+
+  assertEquals(data.triggered_by, 'automated');
+  assertEquals(inserts[0].triggered_by, 'automated');
+});


### PR DESCRIPTION
## Summary
- trigger fix-stuck-bookings with new automated payload
- expose cleanup function handler and return trigger source
- test that automated runs log triggered_by in cleanup_audit

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: dependency conflict)*
- `deno test supabase/functions/fix-stuck-bookings/index.test.ts` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_e_68b810dae590832481c339f45171511d