### PR TITLE
chore: centralize cors headers and unify supabase version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         run: npm ci --legacy-peer-deps
       - name: Lint
         run: npm run lint
+      - name: Check Supabase version consistency
+        run: npm run check:supabase-version
 
   test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check:supabase-version": "node scripts/check-supabase-version.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/check-supabase-version.mjs
+++ b/scripts/check-supabase-version.mjs
@@ -1,0 +1,39 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REQUIRED_VERSION = '2.53.0';
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      yield* walk(full);
+    } else {
+      yield full;
+    }
+  }
+}
+
+const mismatches = [];
+
+for (const file of walk('supabase/functions')) {
+  if (!file.endsWith('.ts') && !file.endsWith('.json')) continue;
+  const content = readFileSync(file, 'utf8');
+  const regex = /@supabase\/supabase-js@([0-9\.]+)/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    const version = match[1];
+    if (version !== REQUIRED_VERSION) {
+      mismatches.push(`${file}: ${match[0]}`);
+    }
+  }
+}
+
+if (mismatches.length) {
+  console.error('Found divergent @supabase/supabase-js versions:');
+  for (const m of mismatches) {
+    console.error(`  ${m}`);
+  }
+  process.exit(1);
+}

--- a/supabase/functions/activity-search/index.ts
+++ b/supabase/functions/activity-search/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/admin-metrics/index.ts
+++ b/supabase/functions/admin-metrics/index.ts
@@ -1,12 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 
 
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 Deno.serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/advanced-alerting/index.ts
+++ b/supabase/functions/advanced-alerting/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface AlertRule {
   id: string

--- a/supabase/functions/advanced-analytics/index.ts
+++ b/supabase/functions/advanced-analytics/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-correlation-id',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface AnalyticsQuery {
   type: 'performance' | 'health' | 'correlation' | 'predictions';

--- a/supabase/functions/advanced-diagnostics/index.ts
+++ b/supabase/functions/advanced-diagnostics/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface DiagnosticResult {
   component: string;

--- a/supabase/functions/ai-training-anonymizer/index.ts
+++ b/supabase/functions/ai-training-anonymizer/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 interface AnonymizationRequest {
   bookingId?: string;

--- a/supabase/functions/amadeus-activity-search/index.ts
+++ b/supabase/functions/amadeus-activity-search/index.ts
@@ -1,5 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
 // Simple logger fallback to avoid import errors
 const logger = {
@@ -9,10 +10,6 @@ const logger = {
   debug: (msg: any, ...args: any[]) => console.debug('[DEBUG]', msg, ...args),
 };
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ActivitySearchParams {
   latitude?: number;

--- a/supabase/functions/amadeus-car-search/index.ts
+++ b/supabase/functions/amadeus-car-search/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-flight-booking/index.ts
+++ b/supabase/functions/amadeus-flight-booking/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-flight-inspiration/index.ts
+++ b/supabase/functions/amadeus-flight-inspiration/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-flight-offers/index.ts
+++ b/supabase/functions/amadeus-flight-offers/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface FlightSearchParams {
   originLocationCode: string;

--- a/supabase/functions/amadeus-flight-price-confirm/index.ts
+++ b/supabase/functions/amadeus-flight-price-confirm/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-flight-search/index.ts
+++ b/supabase/functions/amadeus-flight-search/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 import { getAmadeusAccessToken } from "../_shared/amadeus.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/amadeus-health/index.ts
+++ b/supabase/functions/amadeus-health/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/amadeus-hotel-autocomplete/index.ts
+++ b/supabase/functions/amadeus-hotel-autocomplete/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-hotel-booking/index.ts
+++ b/supabase/functions/amadeus-hotel-booking/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-hotel-details/index.ts
+++ b/supabase/functions/amadeus-hotel-details/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-hotel-list/index.ts
+++ b/supabase/functions/amadeus-hotel-list/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-hotel-offers/index.ts
+++ b/supabase/functions/amadeus-hotel-offers/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/simpleLogger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-hotel-photos/index.ts
+++ b/supabase/functions/amadeus-hotel-photos/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface PhotoRequest {
   hotelId: string;

--- a/supabase/functions/amadeus-hotel-ratings/index.ts
+++ b/supabase/functions/amadeus-hotel-ratings/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-hotel-search/index.ts
+++ b/supabase/functions/amadeus-hotel-search/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 import { getAmadeusAccessToken } from "../_shared/amadeus.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SearchContext {
   destination: string;

--- a/supabase/functions/amadeus-locations-autocomplete/index.ts
+++ b/supabase/functions/amadeus-locations-autocomplete/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 interface AmadeusLocation {
   id: string;

--- a/supabase/functions/amadeus-order-create/index.ts
+++ b/supabase/functions/amadeus-order-create/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusOrderCreateRequest {
   correlationId?: string;

--- a/supabase/functions/amadeus-points-of-interest/index.ts
+++ b/supabase/functions/amadeus-points-of-interest/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-price-confirm/index.ts
+++ b/supabase/functions/amadeus-price-confirm/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-safe-place/index.ts
+++ b/supabase/functions/amadeus-safe-place/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-seat-map/index.ts
+++ b/supabase/functions/amadeus-seat-map/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AmadeusAuthResponse {
   access_token: string;

--- a/supabase/functions/amadeus-transfer-search/index.ts
+++ b/supabase/functions/amadeus-transfer-search/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TransferSearchParams {
   startLocationCode: string;

--- a/supabase/functions/automated-cleanup-scheduler/index.ts
+++ b/supabase/functions/automated-cleanup-scheduler/index.ts
@@ -1,11 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts"
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/automated-recovery-scheduler/index.ts
+++ b/supabase/functions/automated-recovery-scheduler/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ScheduledTask {
   id: string;

--- a/supabase/functions/booking-flow-manager/index.ts
+++ b/supabase/functions/booking-flow-manager/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface BookingFlowRequest {
   step: 'initiate' | 'confirm' | 'complete' | 'cancel';

--- a/supabase/functions/booking-health-monitor/index.ts
+++ b/supabase/functions/booking-health-monitor/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/booking-integrity-manager/index.ts
+++ b/supabase/functions/booking-integrity-manager/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface BookingIntegrityRequest {
   action: 'create_booking' | 'process_payment' | 'confirm_booking' | 'cancel_booking' | 'reconcile_booking';

--- a/supabase/functions/bulk-booking-operations/index.ts
+++ b/supabase/functions/bulk-booking-operations/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface BulkOperationResult {
   booking_id: string;

--- a/supabase/functions/business-intelligence/index.ts
+++ b/supabase/functions/business-intelligence/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface BusinessMetrics {
   revenue: {

--- a/supabase/functions/cancel-payment-intent/index.ts
+++ b/supabase/functions/cancel-payment-intent/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/comprehensive-health-monitor/index.ts
+++ b/supabase/functions/comprehensive-health-monitor/index.ts
@@ -1,10 +1,6 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, validateProductionReadiness, getMTLSConfig } from '../_shared/config.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface HealthCheckResult {
   service: string

--- a/supabase/functions/comprehensive-testing-framework/index.ts
+++ b/supabase/functions/comprehensive-testing-framework/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface TestResult {
   test_name: string

--- a/supabase/functions/comprehensive-testing-suite/index.ts
+++ b/supabase/functions/comprehensive-testing-suite/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 import { ErrorHandler } from "../_shared/errorHandler.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TestResult {
   testName: string;

--- a/supabase/functions/comprehensive-testing/index.ts
+++ b/supabase/functions/comprehensive-testing/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TestResult {
   id: string;

--- a/supabase/functions/configure-auth-security/index.ts
+++ b/supabase/functions/configure-auth-security/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AuthDiagnostics {
   sessionManagement: boolean;

--- a/supabase/functions/confirm-hotel-booking/index.ts
+++ b/supabase/functions/confirm-hotel-booking/index.ts
@@ -1,11 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface ConfirmBookingParams {
   booking_id: string;

--- a/supabase/functions/conversion-tracking/index.ts
+++ b/supabase/functions/conversion-tracking/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/create-activity-booking/index.ts
+++ b/supabase/functions/create-activity-booking/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ActivityBookingParams {
   activityId: string;

--- a/supabase/functions/create-booking-payment/index.ts
+++ b/supabase/functions/create-booking-payment/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 interface BookingPaymentParams {
   bookingType: 'flight' | 'hotel' | 'activity' | 'package';

--- a/supabase/functions/create-booking/index.ts
+++ b/supabase/functions/create-booking/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/create-car-booking/index.ts
+++ b/supabase/functions/create-car-booking/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface CarBookingParams {
   carOffer: {

--- a/supabase/functions/create-card-payment-intent/index.ts
+++ b/supabase/functions/create-card-payment-intent/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 type BookingPaymentParams = {
   bookingType: 'flight' | 'hotel' | 'activity' | 'package';

--- a/supabase/functions/create-flight-booking/index.ts
+++ b/supabase/functions/create-flight-booking/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface FlightBookingParams {
   flightOffers: any[];

--- a/supabase/functions/create-gift-card/index.ts
+++ b/supabase/functions/create-gift-card/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { Resend } from "npm:resend@2.0.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 const resend = new Resend(Deno.env.get("RESEND_API_KEY"));
 

--- a/supabase/functions/create-hotel-booking/index.ts
+++ b/supabase/functions/create-hotel-booking/index.ts
@@ -1,12 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import Stripe from "https://esm.sh/stripe@14.21.0"
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0"
 import logger from "../_shared/logger.ts"
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/create-partner-checkout/index.ts
+++ b/supabase/functions/create-partner-checkout/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 const logStep = (step: string, details?: any) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';

--- a/supabase/functions/create-payment-intent/index.ts
+++ b/supabase/functions/create-payment-intent/index.ts
@@ -1,11 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface CreatePaymentIntentParams {
   booking_type: string;

--- a/supabase/functions/create-transfer-booking/index.ts
+++ b/supabase/functions/create-transfer-booking/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TransferBookingParams {
   transferOffer: {

--- a/supabase/functions/credential-test/index.ts
+++ b/supabase/functions/credential-test/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { ENV_CONFIG, validateProviderCredentials, validateHotelBedsCredentials } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 // Test individual provider authentication
 async function testProviderAuth(provider: 'amadeus' | 'sabre' | 'hotelbeds'): Promise<{

--- a/supabase/functions/critical-alert-system/index.ts
+++ b/supabase/functions/critical-alert-system/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AlertConfig {
   type: string;

--- a/supabase/functions/critical-booking-alerts/index.ts
+++ b/supabase/functions/critical-booking-alerts/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface AlertTrigger {
   type: string;

--- a/supabase/functions/critical-debug/index.ts
+++ b/supabase/functions/critical-debug/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/cron-cleanup-trigger/index.ts
+++ b/supabase/functions/cron-cleanup-trigger/index.ts
@@ -1,11 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts"
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/cross-sell-engine/index.ts
+++ b/supabase/functions/cross-sell-engine/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface CrossSellRequest {
   bookingType: 'flight' | 'hotel' | 'activity';

--- a/supabase/functions/debug-sabre-credentials/index.ts
+++ b/supabase/functions/debug-sabre-credentials/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/deno.importmap.json
+++ b/supabase/functions/deno.importmap.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "https://esm.sh/@supabase/supabase-js@2": "./_test/supabaseClientStub.ts"
+    "https://esm.sh/@supabase/supabase-js@2.53.0": "./_test/supabaseClientStub.ts"
   }
 }

--- a/supabase/functions/deployment-validator/index.ts
+++ b/supabase/functions/deployment-validator/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/document-service/index.ts
+++ b/supabase/functions/document-service/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 Deno.serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/dynamic-sitemap/index.ts
+++ b/supabase/functions/dynamic-sitemap/index.ts
@@ -1,12 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Content-Type': 'application/xml; charset=utf-8'
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/emergency-provider-fix/index.ts
+++ b/supabase/functions/emergency-provider-fix/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/emergency-system-recovery/index.ts
+++ b/supabase/functions/emergency-system-recovery/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface RecoveryAction {
   action: string;

--- a/supabase/functions/enhanced-cleanup/index.ts
+++ b/supabase/functions/enhanced-cleanup/index.ts
@@ -1,12 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import Stripe from 'https://esm.sh/stripe@14.21.0'
 import logger from "../_shared/logger.ts"
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/enhanced-logging/index.ts
+++ b/supabase/functions/enhanced-logging/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-correlation-id',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface LogEntry {
   service_name: string

--- a/supabase/functions/enhanced-notification-service/index.ts
+++ b/supabase/functions/enhanced-notification-service/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 interface CreateNotificationRequest {
   user_id: string;

--- a/supabase/functions/enhanced-provider-health/index.ts
+++ b/supabase/functions/enhanced-provider-health/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from 'https://deno.land/std@0.190.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ProviderConfig {
   id: string;

--- a/supabase/functions/enhanced-provider-rotation/index.ts
+++ b/supabase/functions/enhanced-provider-rotation/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface CircuitBreakerState {
   failureCount: number;

--- a/supabase/functions/enhanced-stripe-webhook/index.ts
+++ b/supabase/functions/enhanced-stripe-webhook/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface StripeWebhookEvent {
   id: string;

--- a/supabase/functions/environment-config/index.ts
+++ b/supabase/functions/environment-config/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { ENV_CONFIG, validateProductionReadiness, getMTLSConfig } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/error-tracking/index.ts
+++ b/supabase/functions/error-tracking/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/simpleLogger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ErrorReport {
   error_type: string;

--- a/supabase/functions/fix-stuck-bookings/index.ts
+++ b/supabase/functions/fix-stuck-bookings/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 export async function handler(req: Request, supabase?: any, stripe?: any) {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/foundation-repair-test/index.ts
+++ b/supabase/functions/foundation-repair-test/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, validateProviderCredentials, validateHotelBedsCredentials } from "../_shared/config.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/funnel-tracking/index.ts
+++ b/supabase/functions/funnel-tracking/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/generate-offers/index.ts
+++ b/supabase/functions/generate-offers/index.ts
@@ -1,5 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
@@ -211,11 +212,6 @@ function getFallbackOffers(): DynamicOffer[] {
       is_active: true
     }
   ];
-}
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
 serve(async (req) => {

--- a/supabase/functions/get-stripe-publishable-key/index.ts
+++ b/supabase/functions/get-stripe-publishable-key/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/guest-booking-lookup/index.ts
+++ b/supabase/functions/guest-booking-lookup/index.ts
@@ -1,11 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface GuestLookupParams {
   bookingId?: string;

--- a/supabase/functions/health-check/index.ts
+++ b/supabase/functions/health-check/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface HealthStatus {
   status: 'healthy' | 'degraded' | 'unhealthy';

--- a/supabase/functions/hotelbeds-activities/index.ts
+++ b/supabase/functions/hotelbeds-activities/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/simpleLogger.ts";
 import { ENV_CONFIG, getHotelBedsCredentials } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ActivitySearchParams {
   destination: string;

--- a/supabase/functions/hotelbeds-autocomplete/index.ts
+++ b/supabase/functions/hotelbeds-autocomplete/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 type Suggestion = {
   id: string;

--- a/supabase/functions/hotelbeds-booking/index.ts
+++ b/supabase/functions/hotelbeds-booking/index.ts
@@ -1,10 +1,6 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, getMTLSConfig, RATE_LIMITS } from '../_shared/config.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface BookingParams {
   holder: {

--- a/supabase/functions/hotelbeds-cancel-booking/index.ts
+++ b/supabase/functions/hotelbeds-cancel-booking/index.ts
@@ -1,10 +1,7 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.54.0';
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import { ENV_CONFIG } from '../_shared/config.ts';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface CancelBookingParams {
   bookingId: string;

--- a/supabase/functions/hotelbeds-checkrates/index.ts
+++ b/supabase/functions/hotelbeds-checkrates/index.ts
@@ -1,10 +1,6 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, RATE_LIMITS } from '../_shared/config.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface CheckratesParams {
   hotelCode: string

--- a/supabase/functions/hotelbeds-content/index.ts
+++ b/supabase/functions/hotelbeds-content/index.ts
@@ -1,10 +1,6 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, RATE_LIMITS } from '../_shared/config.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface ContentParams {
   hotelCodes?: string[]

--- a/supabase/functions/hotelbeds-credential-test/index.ts
+++ b/supabase/functions/hotelbeds-credential-test/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { getHotelBedsCredentials, validateHotelBedsCredentials } from "../_shared/config.ts";
 import logger from "../_shared/simpleLogger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 // Test HotelBeds credentials without making actual API calls
 serve(async (req) => {

--- a/supabase/functions/hotelbeds-image-content/index.ts
+++ b/supabase/functions/hotelbeds-image-content/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { crypto } from "https://deno.land/std@0.190.0/crypto/mod.ts";
 import { getHotelBedsCredentials } from "../_shared/config.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 const generateHotelBedsSignature = async (apiKey: string, secret: string, timestamp: number): Promise<string> => {
   const stringToSign = apiKey + secret + timestamp;

--- a/supabase/functions/hotelbeds-monitoring/index.ts
+++ b/supabase/functions/hotelbeds-monitoring/index.ts
@@ -1,10 +1,6 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, RATE_LIMITS } from '../_shared/config.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface MonitoringEntry {
   endpoint: string

--- a/supabase/functions/hotelbeds-reconfirmation/index.ts
+++ b/supabase/functions/hotelbeds-reconfirmation/index.ts
@@ -1,10 +1,6 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, getMTLSConfig, RATE_LIMITS } from '../_shared/config.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface ReconfirmationParams {
   reference: string

--- a/supabase/functions/hotelbeds-search/index.ts
+++ b/supabase/functions/hotelbeds-search/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { crypto } from "https://deno.land/std@0.190.0/crypto/mod.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { ENV_CONFIG, RATE_LIMITS, getHotelBedsCredentials } from "../_shared/config.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface HotelSearchParams {
   destination: string;

--- a/supabase/functions/hotelbeds-transfers/index.ts
+++ b/supabase/functions/hotelbeds-transfers/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TransferSearchParams {
   fromType: 'ATLAS' | 'IATA' | 'GIATA';

--- a/supabase/functions/load-testing/index.ts
+++ b/supabase/functions/load-testing/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface LoadTestConfig {
   name: string;

--- a/supabase/functions/loyalty-points-manager/index.ts
+++ b/supabase/functions/loyalty-points-manager/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface LoyaltyRequest {
   action: 'earn' | 'redeem' | 'check_balance' | 'get_history' | 'get_tiers';

--- a/supabase/functions/modify-booking/index.ts
+++ b/supabase/functions/modify-booking/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ModificationRequest {
   booking_id: string;

--- a/supabase/functions/notification-service/index.ts
+++ b/supabase/functions/notification-service/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 interface CreateNotificationRequest {
   user_id: string;

--- a/supabase/functions/performance-monitor/index.ts
+++ b/supabase/functions/performance-monitor/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface PerformanceMetric {
   component: string;

--- a/supabase/functions/performance-optimizer/index.ts
+++ b/supabase/functions/performance-optimizer/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface OptimizationTarget {
   type: 'database' | 'cache' | 'api' | 'memory'

--- a/supabase/functions/price-alert-manager/index.ts
+++ b/supabase/functions/price-alert-manager/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface PriceAlert {
   id?: string

--- a/supabase/functions/process-refund/index.ts
+++ b/supabase/functions/process-refund/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface RefundRequest {
   booking_id: string;

--- a/supabase/functions/production-booking-manager/index.ts
+++ b/supabase/functions/production-booking-manager/index.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { corsHeaders } from '../_shared/cors.ts'
 
 interface BookingRequest {

--- a/supabase/functions/production-issue-resolver/index.ts
+++ b/supabase/functions/production-issue-resolver/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ProductionIssue {
   id: string;

--- a/supabase/functions/production-monitoring/index.ts
+++ b/supabase/functions/production-monitoring/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface HealthCheckRequest {
   providers?: string[];

--- a/supabase/functions/production-readiness/index.ts
+++ b/supabase/functions/production-readiness/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 interface ReadinessCheck {
   name: string;

--- a/supabase/functions/production-webhook-handler/index.ts
+++ b/supabase/functions/production-webhook-handler/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface WebhookEvent {
   id: string;

--- a/supabase/functions/provider-api-tester/index.ts
+++ b/supabase/functions/provider-api-tester/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TestRequest {
   provider: string;

--- a/supabase/functions/provider-credential-test/index.ts
+++ b/supabase/functions/provider-credential-test/index.ts
@@ -1,5 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 import { 
   validateProviderCredentials, 
@@ -8,10 +9,6 @@ import {
 } from "../_shared/config.ts";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface CredentialTestResult {
   provider: string;

--- a/supabase/functions/provider-endpoint-validator/index.ts
+++ b/supabase/functions/provider-endpoint-validator/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import { generateHotelBedsSignature } from "../_shared/hotelbeds.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface EndpointTestResult {
   provider: string;

--- a/supabase/functions/provider-quota-monitor/index.ts
+++ b/supabase/functions/provider-quota-monitor/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface QuotaStatus {
   provider: string;

--- a/supabase/functions/provider-rotation/index.ts
+++ b/supabase/functions/provider-rotation/index.ts
@@ -1,5 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 import { 
   validateProviderCredentials, 
@@ -7,10 +8,6 @@ import {
   getAvailableHotelBedsServices 
 } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ProviderConfig {
   id: string;

--- a/supabase/functions/rate-limiter/index.ts
+++ b/supabase/functions/rate-limiter/index.ts
@@ -1,17 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;",
-  "X-Content-Type-Options": "nosniff",
-  "X-Frame-Options": "DENY",
-  "X-XSS-Protection": "1; mode=block",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
-  "Permissions-Policy": "geolocation=(), microphone=(), camera=()"
-};
 
 interface RateLimitRequest {
   identifier: string; // IP or user ID

--- a/supabase/functions/sabre-activities/index.ts
+++ b/supabase/functions/sabre-activities/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken, SABRE_CONFIG } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreActivitySearchRequest {
   destination: string;

--- a/supabase/functions/sabre-air-extras/index.ts
+++ b/supabase/functions/sabre-air-extras/index.ts
@@ -1,14 +1,11 @@
+import { corsHeaders } from '../_shared/cors.ts';
 // Sabre Air Extras (Ancillary Services) Edge Function
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/sabre-air-ticket/index.ts
+++ b/supabase/functions/sabre-air-ticket/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken, SABRE_CONFIG } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreAirTicketRequest {
   pnr: string;

--- a/supabase/functions/sabre-car-search/index.ts
+++ b/supabase/functions/sabre-car-search/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreAuthResponse {
   access_token: string;

--- a/supabase/functions/sabre-flight-booking/index.ts
+++ b/supabase/functions/sabre-flight-booking/index.ts
@@ -1,14 +1,11 @@
+import { corsHeaders } from '../_shared/cors.ts';
 // Sabre Flight Booking (PNR Creation) Edge Function
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/sabre-flight-exchange/index.ts
+++ b/supabase/functions/sabre-flight-exchange/index.ts
@@ -1,14 +1,11 @@
+import { corsHeaders } from '../_shared/cors.ts';
 // Sabre Flight Exchange and Modification Edge Function
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/sabre-flight-offers/index.ts
+++ b/supabase/functions/sabre-flight-offers/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreAuthResponse {
   access_token: string;

--- a/supabase/functions/sabre-flight-price/index.ts
+++ b/supabase/functions/sabre-flight-price/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken, SABRE_CONFIG } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreAirPriceRequest {
   itinerary: any;

--- a/supabase/functions/sabre-flight-search/index.ts
+++ b/supabase/functions/sabre-flight-search/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/sabre-health/index.ts
+++ b/supabase/functions/sabre-health/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/sabre-hotel-content/index.ts
+++ b/supabase/functions/sabre-hotel-content/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreHotelContentRequest {
   hotelId: string;

--- a/supabase/functions/sabre-hotel-search/index.ts
+++ b/supabase/functions/sabre-hotel-search/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface SabreAuthResponse {
   access_token: string;

--- a/supabase/functions/sabre-locations-autocomplete/index.ts
+++ b/supabase/functions/sabre-locations-autocomplete/index.ts
@@ -1,7 +1,4 @@
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeaders } from '../_shared/cors.ts';
 
 interface SabreAuthResponse {
   access_token: string;

--- a/supabase/functions/sabre-pnr-management/index.ts
+++ b/supabase/functions/sabre-pnr-management/index.ts
@@ -1,14 +1,11 @@
+import { corsHeaders } from '../_shared/cors.ts';
 // Sabre PNR Management (Retrieve, Modify, Cancel) Edge Function
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/sabre-seat-selection/index.ts
+++ b/supabase/functions/sabre-seat-selection/index.ts
@@ -1,14 +1,11 @@
+import { corsHeaders } from '../_shared/cors.ts';
 // Sabre Seat Selection Edge Function
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/sabre-travel-alerts/index.ts
+++ b/supabase/functions/sabre-travel-alerts/index.ts
@@ -1,14 +1,11 @@
+import { corsHeaders } from '../_shared/cors.ts';
 // Sabre Travel Alerts (Schedule Changes, Notifications) Edge Function
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/scalability-manager/index.ts
+++ b/supabase/functions/scalability-manager/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface ScalabilityConfig {
   auto_scaling: {

--- a/supabase/functions/secure-admin-dashboard/index.ts
+++ b/supabase/functions/secure-admin-dashboard/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/security-cleanup/index.ts
+++ b/supabase/functions/security-cleanup/index.ts
@@ -1,17 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;",
-  "X-Content-Type-Options": "nosniff",
-  "X-Frame-Options": "DENY",
-  "X-XSS-Protection": "1; mode=block",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
-  "Permissions-Policy": "geolocation=(), microphone=(), camera=()"
-};
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {

--- a/supabase/functions/security-hardening/index.ts
+++ b/supabase/functions/security-hardening/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface SecurityScan {
   id: string

--- a/supabase/functions/self-healing-executor/index.ts
+++ b/supabase/functions/self-healing-executor/index.ts
@@ -1,9 +1,5 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 
 interface HealingAction {
   type: 'provider_reset' | 'cache_clear' | 'connection_refresh' | 'config_reload'

--- a/supabase/functions/send-booking-confirmation/index.ts
+++ b/supabase/functions/send-booking-confirmation/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { Resend } from "npm:resend@2.0.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface BookingConfirmationRequest {
   bookingId: string;

--- a/supabase/functions/send-gift-card-email/index.ts
+++ b/supabase/functions/send-gift-card-email/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import { Resend } from "npm:resend@2.0.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 const resend = new Resend(Deno.env.get("RESEND_API_KEY"));
 

--- a/supabase/functions/sentry-setup-guide/index.ts
+++ b/supabase/functions/sentry-setup-guide/index.ts
@@ -1,9 +1,5 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,18 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.stripe.com;",
-  "X-Content-Type-Options": "nosniff",
-  "X-Frame-Options": "DENY", 
-  "X-XSS-Protection": "1; mode=block",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
-  "Permissions-Policy": "geolocation=(), microphone=(), camera=()"
-};
 
 const logStep = (step: string, details?: any) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';

--- a/supabase/functions/test-critical-path/index.ts
+++ b/supabase/functions/test-critical-path/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import { corsHeaders } from "../_shared/cors.ts";
 
 const supabase = createClient(

--- a/supabase/functions/test-deployment/index.ts
+++ b/supabase/functions/test-deployment/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   // Handle CORS preflight requests

--- a/supabase/functions/test-infrastructure-activation/index.ts
+++ b/supabase/functions/test-infrastructure-activation/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from 'https://deno.land/std@0.190.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TestResult {
   testId: string;

--- a/supabase/functions/test-provider-rotation/index.ts
+++ b/supabase/functions/test-provider-rotation/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/track-performance/index.ts
+++ b/supabase/functions/track-performance/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface PerformanceMetric {
   component: string;

--- a/supabase/functions/travelport-search/index.ts
+++ b/supabase/functions/travelport-search/index.ts
@@ -1,10 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface TravelportSearchParams {
   type: 'flight' | 'hotel' | 'car';

--- a/supabase/functions/unified-health-monitor/index.ts
+++ b/supabase/functions/unified-health-monitor/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 interface ProviderHealthStatus {
   providerId: string;

--- a/supabase/functions/unified-search/index.ts
+++ b/supabase/functions/unified-search/index.ts
@@ -1,17 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;",
-  'X-Content-Type-Options': 'nosniff',
-  'X-Frame-Options': 'DENY',
-  'X-XSS-Protection': '1; mode=block',
-  'Referrer-Policy': 'strict-origin-when-cross-origin',
-  'Permissions-Policy': 'geolocation=(), microphone=(), camera=()'
-};
 
 interface SearchParams {
   type: 'flight' | 'hotel' | 'activity' | 'car' | 'transfer';

--- a/supabase/functions/validate-gift-card/index.ts
+++ b/supabase/functions/validate-gift-card/index.ts
@@ -1,11 +1,8 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 interface ValidateGiftCardRequest {
   code: string;

--- a/supabase/functions/validate-passport/index.ts
+++ b/supabase/functions/validate-passport/index.ts
@@ -1,5 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts";
 
 interface PassportData {
@@ -220,11 +221,6 @@ function parseTextractPassportData(textractResult: any): PassportData {
     isValid,
     confidence
   };
-}
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
 serve(async (req) => {

--- a/supabase/functions/validate-provider-compliance/index.ts
+++ b/supabase/functions/validate-provider-compliance/index.ts
@@ -1,13 +1,10 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import logger from "../_shared/logger.ts";
 import { ENV_CONFIG } from "../_shared/config.ts";
 import { getSabreAccessToken } from "../_shared/sabre.ts";
 import { generateHotelBedsSignature } from "../_shared/hotelbeds.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface ComplianceTestResult {
   provider: string;

--- a/supabase/functions/verify-booking-payment/index.ts
+++ b/supabase/functions/verify-booking-payment/index.ts
@@ -1,13 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0"
 import Stripe from "https://esm.sh/stripe@14.21.0"
 import { Resend } from "npm:resend@2.0.0"
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 async function sendConfirmationEmail(booking: any, bookingId: string, supabaseClient: any) {
   try {

--- a/supabase/functions/verify-flight-price/index.ts
+++ b/supabase/functions/verify-flight-price/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface FlightPriceVerificationRequest {
   offerId: string;

--- a/supabase/functions/verify-hotel-rate/index.ts
+++ b/supabase/functions/verify-hotel-rate/index.ts
@@ -1,9 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
 
 interface HotelRateVerificationRequest {
   hotelId: string;

--- a/supabase/functions/verify-partner-payment/index.ts
+++ b/supabase/functions/verify-partner-payment/index.ts
@@ -1,12 +1,9 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
 import logger from "../_shared/logger.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
 
 const logStep = (step: string, details?: any) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';

--- a/supabase/functions/verify-payment-and-complete-booking/index.ts
+++ b/supabase/functions/verify-payment-and-complete-booking/index.ts
@@ -1,11 +1,7 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 import logger from "../_shared/logger.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
 
 interface VerifyPaymentParams {
   payment_intent_id: string;

--- a/supabase/functions/webhook-idempotency/index.ts
+++ b/supabase/functions/webhook-idempotency/index.ts
@@ -1,10 +1,6 @@
+import { corsHeaders } from '../_shared/cors.ts';
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, stripe-signature',
-}
+import { createClient } from 'jsr:@supabase/supabase-js@2.53.0'
 
 interface IdempotencyRecord {
   id: string;


### PR DESCRIPTION
## Summary
- import shared `corsHeaders` across all edge functions
- standardize `@supabase/supabase-js` imports to version `2.53.0`
- add CI check to enforce consistent Supabase SDK version

## Testing
- `npm run check:supabase-version`
- `npm run lint` *(fails: Unexpected any and require import errors)*
- `npm test` *(fails: missing describe/localStorage and edge runtime imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b8143b8fac832489cea4e0cd63b5f3