### PR TITLE
chore: use env vars for supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ npm i
 npm run dev
 ```
 
+## Environment configuration
+
+This project expects Supabase credentials to be provided via Vite environment variables.
+
+### Local development
+
+Create a `.env.local` file in the project root with the following values:
+
+```
+VITE_SUPABASE_URL=your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+```
+
+Restart the development server after adding or modifying the file.
+
+### Production deployment
+
+Configure the same environment variables in your hosting provider (e.g., Netlify, Vercel). Consult your provider's documentation for setting build-time environment variables.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://iomeddeasarntjhqzndu.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlvbWVkZGVhc2FybnRqaHF6bmR1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQzODk0NjksImV4cCI6MjA2OTk2NTQ2OX0.tZ50J9PPa6ZqDdPF0-WPYwoLO-aGBIf6Qtjr7dgYrDI";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,12 @@
 
 /// <reference types="vite/client" />
 /// <reference types="vitest/globals" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_ANON_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,4 +34,5 @@ export default defineConfig(({ mode }) => ({
     // Force cache busting with build timestamp
     __BUILD_TIMESTAMP__: JSON.stringify(Date.now()),
   },
+  envPrefix: "VITE_",
 }));


### PR DESCRIPTION
## Summary
- load Supabase URL and key from Vite env vars
- expose VITE_SUPABASE_* in Vite config and types
- document Supabase environment setup for dev and production

## Testing
- `npm test` *(fails: Only URLs with a scheme in: file and data are supported by the default ESM loader. Received protocol 'https:' etc.; multiple suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b816d290088324a6046b171d294c1f