### PR TITLE
Enforce core provider IDs and schedule cleanup job

### DIFF
--- a/supabase/functions/provider-config-cleanup/index.ts
+++ b/supabase/functions/provider-config-cleanup/index.ts
@@ -1,0 +1,71 @@
+import { corsHeaders } from '../_shared/cors.ts';
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
+import logger from "../_shared/logger.ts";
+
+const CORE_PROVIDERS = ['amadeus','sabre-flight','sabre-hotel','hotelbeds-hotel','hotelbeds-activity'];
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  const startTime = Date.now();
+  const correlationId = crypto.randomUUID();
+  logger.info('Provider config cleanup started', { correlationId });
+
+  try {
+    const { data: offenders, error: fetchError } = await supabase
+      .from('provider_configs')
+      .select('id')
+      .not('id', 'in', `(${CORE_PROVIDERS.map(id => `'${id}'`).join(',')})`);
+
+    if (fetchError) throw fetchError;
+
+    const removedIds = offenders?.map(o => o.id) ?? [];
+
+    if (removedIds.length > 0) {
+      const { error: deleteError } = await supabase
+        .from('provider_configs')
+        .delete()
+        .not('id', 'in', `(${CORE_PROVIDERS.map(id => `'${id}'`).join(',')})`);
+
+      if (deleteError) throw deleteError;
+
+      const { error: auditError } = await supabase.from('cleanup_audit').insert({
+        cleanup_type: 'provider_config_cleanup',
+        errors_encountered: 0,
+        execution_time_ms: Date.now() - startTime,
+        triggered_by: 'cron',
+        details: { removed_providers: removedIds }
+      });
+
+      if (auditError) logger.error('Failed to log cleanup', auditError, { correlationId });
+
+      logger.warn('Removed non-core providers', { correlationId, removedIds });
+    } else {
+      logger.info('No non-core providers found', { correlationId });
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        removed: removedIds,
+        correlationId
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    logger.error('Provider config cleanup failed', error, { correlationId });
+
+    return new Response(
+      JSON.stringify({ success: false, error: error.message, correlationId }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/migrations/20250903112130_109c8f5c-42c2-4e3d-9256-93ffc2d5407f.sql
+++ b/supabase/migrations/20250903112130_109c8f5c-42c2-4e3d-9256-93ffc2d5407f.sql
@@ -1,0 +1,36 @@
+-- Enforce core provider IDs and schedule cleanup
+
+-- 1. Prevent inserts of unknown provider IDs
+ALTER TABLE public.provider_configs
+  ADD CONSTRAINT provider_configs_core_ids_check
+    CHECK (id IN ('amadeus','sabre-flight','sabre-hotel','hotelbeds-hotel','hotelbeds-activity'));
+
+-- 2. Schedule periodic cleanup of non-core providers
+SELECT cron.schedule(
+  'provider-config-cleanup',
+  '0 * * * *',
+  $$
+  SELECT
+    net.http_post(
+      url:='https://iomeddeasarntjhqzndu.supabase.co/functions/v1/provider-config-cleanup',
+      headers:='{"Content-Type": "application/json", "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlvbWVkZGVhc2FybnRqaHF6bmR1Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDM4OTQ2OSwiZXhwIjoyMDY5OTY1NDY5fQ.d6CdnpT5BkVJLjhVZvyQFCPEIFhH0xQWf6XNjQNjqJM"}'::jsonb,
+      body:='{}'::jsonb
+    ) as request_id;
+  $$
+);
+
+-- Trigger to provide clear error message on invalid provider IDs
+CREATE OR REPLACE FUNCTION public.check_core_provider_id()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.id NOT IN ('amadeus','sabre-flight','sabre-hotel','hotelbeds-hotel','hotelbeds-activity') THEN
+    RAISE EXCEPTION 'Unknown provider id: %', NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS enforce_core_provider_id ON public.provider_configs;
+CREATE TRIGGER enforce_core_provider_id
+  BEFORE INSERT ON public.provider_configs
+  FOR EACH ROW EXECUTE FUNCTION public.check_core_provider_id();


### PR DESCRIPTION
## Summary
- restrict provider_configs to core provider IDs using constraint and trigger
- add hourly cron job to purge non-core providers
- implement provider-config-cleanup edge function to remove and audit offenders

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: OffersWidget renders offers; PaymentVault; PassportUploader etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8246e1b6083249facf52dab8fe0a6