### PR TITLE
Add booking operation component and edge-function tests

### DIFF
--- a/src/components/admin/__tests__/BookingManagement.test.tsx
+++ b/src/components/admin/__tests__/BookingManagement.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BookingManagement } from '../BookingManagement';
+import { supabase } from '@/integrations/supabase/client';
+import { vi, expect } from 'vitest';
+import React from 'react';
+
+const bookings = [
+  {
+    id: '1',
+    booking_reference: 'AAA111',
+    booking_type: 'hotel',
+    status: 'pending',
+    total_amount: 100,
+    currency: 'USD',
+    created_at: new Date().toISOString(),
+    user_id: 'u1',
+    booking_data: { customerInfo: { email: 'a@example.com' } }
+  },
+  {
+    id: '2',
+    booking_reference: 'BBB222',
+    booking_type: 'flight',
+    status: 'confirmed',
+    total_amount: 200,
+    currency: 'USD',
+    created_at: new Date().toISOString(),
+    user_id: 'u2',
+    booking_data: { customerInfo: { email: 'b@example.com' } }
+  }
+];
+
+const inserts: any[] = [];
+
+vi.mock('@/utils/logger', () => ({ default: { info: vi.fn(), error: vi.fn() } }));
+
+vi.mock('@/integrations/supabase/client', () => {
+  const supabase = {
+    from: (table: string) => {
+      if (table === 'bookings') {
+        return {
+          select: () => ({
+            order: () => ({
+              limit: () => Promise.resolve({ data: bookings, error: null })
+            })
+          })
+        };
+      }
+      if (table === 'test_results') {
+        return {
+          insert: (data: any) => {
+            inserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }
+        };
+      }
+      return {};
+    }
+  } as any;
+  return { supabase };
+});
+
+async function logResult(name: string, passed: boolean) {
+  await supabase.from('test_results').insert({ test_name: name, status: passed ? 'passed' : 'failed' });
+}
+
+describe('BookingManagement', () => {
+  beforeEach(() => {
+    inserts.length = 0;
+  });
+
+  it('displays bookings from supabase', async () => {
+    const testName = 'BookingManagement displays bookings';
+    try {
+      render(<BookingManagement />);
+      expect(await screen.findByText('AAA111')).toBeInTheDocument();
+      await logResult(testName, true);
+    } catch (err) {
+      await logResult(testName, false);
+      throw err;
+    }
+    expect(inserts.find(r => r.test_name === testName)?.status).toBe('passed');
+  });
+
+  it('filters bookings by search term', async () => {
+    const testName = 'BookingManagement search filter';
+    try {
+      render(<BookingManagement />);
+      await screen.findByText('AAA111');
+      const input = screen.getByPlaceholderText('Search by booking reference or ID...');
+      fireEvent.change(input, { target: { value: 'BBB222' } });
+      expect(screen.queryByText('AAA111')).not.toBeInTheDocument();
+      await logResult(testName, true);
+    } catch (err) {
+      await logResult(testName, false);
+      throw err;
+    }
+    expect(inserts.find(r => r.test_name === testName)?.status).toBe('passed');
+  });
+});
+

--- a/src/components/admin/__tests__/EnhancedBookingOperations.test.tsx
+++ b/src/components/admin/__tests__/EnhancedBookingOperations.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EnhancedBookingOperations } from '../EnhancedBookingOperations';
+import { supabase } from '@/integrations/supabase/client';
+import { vi, expect } from 'vitest';
+import React from 'react';
+
+const mockBookingRow = {
+  id: '1',
+  booking_reference: 'ABC123',
+  booking_type: 'hotel',
+  status: 'failed',
+  total_amount: 100,
+  currency: 'USD',
+  booking_data: { customerInfo: { firstName: 'John', lastName: 'Doe', email: 'john@example.com' } },
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString()
+};
+
+const inserts: any[] = [];
+var invokeMock: any;
+
+vi.mock('@/integrations/supabase/client', () => {
+  invokeMock = vi.fn(async (fn: string, _args: any) => {
+    if (fn === 'critical-booking-alerts') {
+      return { data: { active_alerts: [] }, error: null };
+    }
+    if (fn === 'bulk-booking-operations') {
+      return { data: { summary: { success: 1, failed: 0 }, results: [{ booking_id: '1', status: 'success' }] }, error: null };
+    }
+    return { data: {}, error: null };
+  });
+
+  const supabase = {
+    from: (table: string) => {
+      if (table === 'bookings') {
+        return {
+          select: () => ({
+            order: () => ({
+              limit: () => Promise.resolve({ data: [mockBookingRow], error: null })
+            })
+          }),
+          update: () => ({ eq: () => Promise.resolve({ data: null, error: null }) })
+        };
+      }
+      if (table === 'booking_status_history') {
+        return { insert: () => Promise.resolve({ data: null, error: null }) };
+      }
+      if (table === 'test_results') {
+        return {
+          insert: (data: any) => {
+            inserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }
+        };
+      }
+      return {};
+    },
+    functions: { invoke: invokeMock }
+  } as any;
+  return { supabase };
+});
+
+async function logResult(name: string, passed: boolean) {
+  await supabase.from('test_results').insert({ test_name: name, status: passed ? 'passed' : 'failed' });
+}
+
+describe('EnhancedBookingOperations', () => {
+  beforeEach(() => {
+    invokeMock.mockClear();
+    inserts.length = 0;
+  });
+
+  it('loads bookings and displays them', async () => {
+    const testName = 'EnhancedBookingOperations loads bookings';
+    try {
+      render(<EnhancedBookingOperations />);
+      expect(await screen.findByText('ABC123')).toBeInTheDocument();
+      await logResult(testName, true);
+    } catch (err) {
+      await logResult(testName, false);
+      throw err;
+    }
+    expect(inserts.find(r => r.test_name === testName)?.status).toBe('passed');
+  });
+
+  it('performs bulk retry operation', async () => {
+    const testName = 'EnhancedBookingOperations bulk retry';
+    try {
+      render(<EnhancedBookingOperations />);
+      await screen.findByText('ABC123');
+      const checkboxes = screen.getAllByRole('checkbox');
+      fireEvent.click(checkboxes[1]);
+      const retryButton = screen.getByText(/Retry Selected/);
+      fireEvent.click(retryButton);
+      await waitFor(() => {
+        expect(invokeMock).toHaveBeenCalledWith(
+          'bulk-booking-operations',
+          expect.objectContaining({ body: expect.objectContaining({ operationType: 'retry', bookingIds: ['1'] }) })
+        );
+      });
+      await logResult(testName, true);
+    } catch (err) {
+      await logResult(testName, false);
+      throw err;
+    }
+    expect(inserts.find(r => r.test_name === testName)?.status).toBe('passed');
+  });
+});
+

--- a/src/components/production/__tests__/BookingStatusResolver.test.tsx
+++ b/src/components/production/__tests__/BookingStatusResolver.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BookingStatusResolver } from '../BookingStatusResolver';
+import { supabase } from '@/integrations/supabase/client';
+import { vi, expect } from 'vitest';
+import React from 'react';
+
+const mockBooking = {
+  id: '1',
+  booking_reference: 'STUCK1',
+  status: 'pending',
+  created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  total_amount: 150,
+  currency: 'USD',
+  booking_type: 'hotel'
+};
+
+const inserts: any[] = [];
+var invokeMock: any;
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/integrations/supabase/client', () => {
+  invokeMock = vi.fn(async () => ({ data: { summary: { confirmed: 1 }, results: [] }, error: null }));
+
+  const supabase = {
+    from: (table: string) => {
+      if (table === 'bookings') {
+        return {
+          select: () => ({
+            eq: () => ({
+              lt: () => ({
+                order: () => ({
+                  limit: () => Promise.resolve({ data: [mockBooking], error: null })
+                })
+              })
+            })
+          })
+        };
+      }
+      if (table === 'test_results') {
+        return {
+          insert: (data: any) => {
+            inserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }
+        };
+      }
+      return {};
+    },
+    functions: { invoke: invokeMock }
+  } as any;
+  return { supabase };
+});
+
+async function logResult(name: string, passed: boolean) {
+  await supabase.from('test_results').insert({ test_name: name, status: passed ? 'passed' : 'failed' });
+}
+
+describe('BookingStatusResolver', () => {
+  beforeEach(() => {
+    invokeMock.mockClear();
+    inserts.length = 0;
+  });
+
+  it('renders stuck bookings', async () => {
+    const testName = 'BookingStatusResolver renders stuck bookings';
+    try {
+      render(<BookingStatusResolver />);
+      expect(await screen.findByText('STUCK1')).toBeInTheDocument();
+      await logResult(testName, true);
+    } catch (err) {
+      await logResult(testName, false);
+      throw err;
+    }
+    expect(inserts.find(r => r.test_name === testName)?.status).toBe('passed');
+  });
+
+  it('runs bulk resolution', async () => {
+    const testName = 'BookingStatusResolver bulk resolve';
+    try {
+      render(<BookingStatusResolver />);
+      await screen.findByText('STUCK1');
+      fireEvent.click(screen.getByText('Resolve All'));
+      expect(invokeMock).toHaveBeenCalledWith('fix-stuck-bookings');
+      await logResult(testName, true);
+    } catch (err) {
+      await logResult(testName, false);
+      throw err;
+    }
+    expect(inserts.find(r => r.test_name === testName)?.status).toBe('passed');
+  });
+});
+

--- a/supabase/functions/bulk-booking-operations/index.test.ts
+++ b/supabase/functions/bulk-booking-operations/index.test.ts
@@ -1,0 +1,71 @@
+import { handler } from "./index.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: ${actual} !== ${expected}`);
+  }
+}
+
+Deno.test("bulk booking retry operation", async () => {
+  const inserts: any[] = [];
+  const supabaseStub = {
+    from: (table: string) => {
+      if (table === 'bookings') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({
+                data: {
+                  id: '1',
+                  booking_reference: 'ABC',
+                  status: 'failed',
+                  booking_type: 'hotel',
+                  booking_data: {},
+                  total_amount: 100,
+                  currency: 'USD'
+                },
+                error: null
+              })
+            })
+          }),
+          update: () => ({ eq: () => Promise.resolve({ data: null, error: null }) })
+        };
+      }
+      if (table === 'booking_status_history') {
+        return { insert: () => Promise.resolve({ data: null, error: null }) };
+      }
+      if (table === 'test_results') {
+        return {
+          insert: (data: any) => {
+            inserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }
+        };
+      }
+      return {};
+    },
+    functions: { invoke: () => Promise.resolve({ data: {}, error: null }) }
+  } as any;
+
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({
+      operation: 'bulk_operation',
+      operationType: 'retry',
+      bookingIds: ['1'],
+      correlationId: 'test'
+    })
+  });
+
+  const res = await handler(req, supabaseStub);
+  const data = await res.json();
+
+  assertEquals(data.results[0].status, 'success');
+
+  await supabaseStub.from('test_results').insert({
+    test_name: 'bulk booking retry operation',
+    status: data.results[0].status === 'success' ? 'passed' : 'failed'
+  });
+  assertEquals(inserts[0].status, 'passed');
+});
+

--- a/supabase/functions/critical-booking-alerts/index.test.ts
+++ b/supabase/functions/critical-booking-alerts/index.test.ts
@@ -1,0 +1,55 @@
+import { handler } from "./index.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: ${actual} !== ${expected}`);
+  }
+}
+
+Deno.test("returns active critical alerts", async () => {
+  const inserts: any[] = [];
+  const supabaseStub = {
+    from: (table: string) => {
+      if (table === 'critical_alerts') {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({
+                  data: [{ id: 1, resolved: false }],
+                  error: null
+                })
+              })
+            })
+          })
+        };
+      }
+      if (table === 'test_results') {
+        return {
+          insert: (data: any) => {
+            inserts.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }
+        };
+      }
+      return {};
+    }
+  } as any;
+
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ action: 'get_active_alerts' })
+  });
+
+  const res = await handler(req, supabaseStub);
+  const data = await res.json();
+
+  assertEquals(data.count, 1);
+
+  await supabaseStub.from('test_results').insert({
+    test_name: 'critical alerts get active',
+    status: data.count === 1 ? 'passed' : 'failed'
+  });
+  assertEquals(inserts[0].status, 'passed');
+});
+


### PR DESCRIPTION
## Summary
- add handler exports for bulk-booking-operations and critical-booking-alerts functions
- add component tests for EnhancedBookingOperations, BookingStatusResolver, and BookingManagement with Supabase logging
- add edge-function tests with mocked Supabase responses and test_results integration

## Testing
- `npm test -- src/components/admin/__tests__/EnhancedBookingOperations.test.tsx src/components/production/__tests__/BookingStatusResolver.test.tsx src/components/admin/__tests__/BookingManagement.test.tsx` *(fails: TypeError: expectAssertion.call is not a function)*
- `deno test supabase/functions/bulk-booking-operations/index.test.ts supabase/functions/critical-booking-alerts/index.test.ts` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_e_68b82605be608324b3dc299dee803cf1