### PR TITLE
feat(store): add typed booking state

### DIFF
--- a/src/store/bookingStore.ts
+++ b/src/store/bookingStore.ts
@@ -1,32 +1,85 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type {
+  AmadeusActivity,
+  AmadeusFlightOffer,
+  AmadeusHotel,
+  AmadeusHotelOffer,
+} from '@/types/amadeus';
+
+interface HotelBookingDetails {
+  hotel: AmadeusHotel;
+  checkInDate: string;
+  checkOutDate: string;
+  nights: number;
+  guestCount: number;
+  roomCount: number;
+  totalAmount: number;
+  currency: string;
+}
+
+interface HotelAddOn {
+  id: string;
+  name: string;
+  price: number;
+  quantity?: number;
+  description?: string;
+  isPerPerson?: boolean;
+}
+
+interface GuestInfo {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  title?: string;
+  arrivalTime?: string;
+  specialRequests?: string;
+  roomPreferences?: string;
+  smsNotifications?: boolean;
+  emailUpdates?: boolean;
+}
+
+interface PassengerInfo extends GuestInfo {
+  middleName?: string;
+  dateOfBirth: string;
+  gender: 'M' | 'F' | 'X';
+  passportNumber?: string;
+  passportExpiry?: string;
+  nationality?: string;
+}
 
 interface BookingState {
   // Hotel booking state
-  selectedHotelOffer: any | null;
-  selectedHotelData: any | null;
-  selectedAddOns: any[];
+  selectedHotelOffer: AmadeusHotelOffer | null;
+  selectedHotelData: HotelBookingDetails | null;
+  selectedAddOns: HotelAddOn[];
   addOnsTotal: number;
-  
+
   // Flight booking state
-  selectedOutboundFlight: any | null;
-  selectedInboundFlight: any | null;
-  multiCityFlights: any[];
-  tripType: string;
-  
+  selectedOutboundFlight: AmadeusFlightOffer | null;
+  selectedInboundFlight: AmadeusFlightOffer | null;
+  multiCityFlights: AmadeusFlightOffer[];
+  tripType: 'oneway' | 'roundtrip' | 'multicity';
+
   // Activity booking state
-  selectedActivityOffer: any | null;
-  
+  selectedActivityOffer: AmadeusActivity | null;
+
   // Guest/Passenger info
-  guestInfo: any | null;
-  passengerInfo: any | null;
-  
+  guestInfo: GuestInfo | null;
+  passengerInfo: PassengerInfo | null;
+
   // Actions
-  setHotelBooking: (offer: any, data: any, addOns: any[], total: number) => void;
-  setFlightBooking: (outbound: any, inbound?: any, multiCity?: any[], type?: string) => void;
-  setActivityBooking: (offer: any) => void;
-  setGuestInfo: (info: any) => void;
-  setPassengerInfo: (info: any) => void;
+  setHotelBooking: (offer: AmadeusHotelOffer, data: HotelBookingDetails, addOns: HotelAddOn[], total: number) => void;
+  setFlightBooking: (
+    outbound: AmadeusFlightOffer,
+    inbound?: AmadeusFlightOffer,
+    multiCity?: AmadeusFlightOffer[],
+    type?: 'oneway' | 'roundtrip' | 'multicity'
+  ) => void;
+  setActivityBooking: (offer: AmadeusActivity) => void;
+  setGuestInfo: (info: GuestInfo) => void;
+  setPassengerInfo: (info: PassengerInfo) => void;
   clearBooking: () => void;
 }
 
@@ -45,63 +98,82 @@ export const useBookingStore = create<BookingState>()(
       selectedActivityOffer: null,
       guestInfo: null,
       passengerInfo: null,
-      
+
       // Actions
-      setHotelBooking: (offer, data, addOns, total) => set({
-        selectedHotelOffer: offer,
-        selectedHotelData: data,
-        selectedAddOns: addOns,
-        addOnsTotal: total
-      }),
-      
-      setFlightBooking: (outbound, inbound, multiCity, type) => set({
-        selectedOutboundFlight: outbound,
-        selectedInboundFlight: inbound,
-        multiCityFlights: multiCity || [],
-        tripType: type || 'oneway'
-      }),
-      
-      setActivityBooking: (offer) => set({
-        selectedActivityOffer: offer
-      }),
-      
-      setGuestInfo: (info) => set({
-        guestInfo: info
-      }),
-      
-      setPassengerInfo: (info) => set({
-        passengerInfo: info
-      }),
-      
-      clearBooking: () => set({
-        selectedHotelOffer: null,
-        selectedHotelData: null,
-        selectedAddOns: [],
-        addOnsTotal: 0,
-        selectedOutboundFlight: null,
-        selectedInboundFlight: null,
-        multiCityFlights: [],
-        tripType: 'oneway',
-        selectedActivityOffer: null,
-        guestInfo: null,
-        passengerInfo: null
-      })
+      setHotelBooking: (offer, data, addOns, total) =>
+        set({
+          selectedHotelOffer: offer,
+          selectedHotelData: data,
+          selectedAddOns: addOns,
+          addOnsTotal: total,
+        }),
+
+      setFlightBooking: (outbound, inbound, multiCity, type) =>
+        set({
+          selectedOutboundFlight: outbound,
+          selectedInboundFlight: inbound || null,
+          multiCityFlights: multiCity || [],
+    tripType: type || 'oneway',
+        }),
+
+      setActivityBooking: (offer) =>
+        set({
+          selectedActivityOffer: offer,
+        }),
+
+      setGuestInfo: (info) =>
+        set({
+          guestInfo: info,
+        }),
+
+      setPassengerInfo: (info) =>
+        set({
+          passengerInfo: info,
+        }),
+
+      clearBooking: () =>
+        set({
+          selectedHotelOffer: null,
+          selectedHotelData: null,
+          selectedAddOns: [],
+          addOnsTotal: 0,
+          selectedOutboundFlight: null,
+          selectedInboundFlight: null,
+          multiCityFlights: [],
+          tripType: 'oneway',
+          selectedActivityOffer: null,
+          guestInfo: null,
+          passengerInfo: null,
+        }),
     }),
     {
       name: 'booking-store',
-      partialize: (state) => ({
-        selectedHotelOffer: state.selectedHotelOffer,
-        selectedHotelData: state.selectedHotelData,
-        selectedAddOns: state.selectedAddOns,
-        addOnsTotal: state.addOnsTotal,
-        selectedOutboundFlight: state.selectedOutboundFlight,
-        selectedInboundFlight: state.selectedInboundFlight,
-        multiCityFlights: state.multiCityFlights,
-        tripType: state.tripType,
-        selectedActivityOffer: state.selectedActivityOffer,
-        guestInfo: state.guestInfo,
-        passengerInfo: state.passengerInfo
-      })
+      partialize: (state) => sanitizeBookingState(state),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...sanitizeBookingState(persistedState as Partial<BookingState>),
+      }),
     }
   )
 );
+
+function sanitizeBookingState(state: Partial<BookingState>): Partial<BookingState> {
+  return {
+    selectedHotelOffer: state.selectedHotelOffer ?? null,
+    selectedHotelData: state.selectedHotelData ?? null,
+    selectedAddOns: Array.isArray(state.selectedAddOns) ? state.selectedAddOns : [],
+    addOnsTotal: typeof state.addOnsTotal === 'number' ? state.addOnsTotal : 0,
+    selectedOutboundFlight: state.selectedOutboundFlight ?? null,
+    selectedInboundFlight: state.selectedInboundFlight ?? null,
+    multiCityFlights: Array.isArray(state.multiCityFlights)
+      ? state.multiCityFlights
+      : [],
+    tripType:
+      state.tripType === 'roundtrip' || state.tripType === 'multicity'
+        ? state.tripType
+        : 'oneway',
+    selectedActivityOffer: state.selectedActivityOffer ?? null,
+    guestInfo: state.guestInfo ?? null,
+    passengerInfo: state.passengerInfo ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- define structured interfaces for hotel, flight, activity and traveler info
- type booking store actions and sanitize persisted state

## Testing
- `npm test` *(fails: 8 failed)*
- `npm run lint` *(fails: 1707 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b84251707c8324a1e74b9766578d97