### PR TITLE
refactor: secure unified search service invocation

### DIFF
--- a/supabase/functions/unified-search/index.test.ts
+++ b/supabase/functions/unified-search/index.test.ts
@@ -4,7 +4,7 @@ import { stub, returnsNext, FakeTime } from "https://deno.land/std@0.190.0/testi
 
 // Mock environment variables
 Deno.env.set('SUPABASE_URL', 'https://test.supabase.co');
-Deno.env.set('SUPABASE_ANON_KEY', 'test-key');
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-key');
 
 // Mock global fetch for currency API calls
 const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary
- use service role key from environment when invoking Supabase functions
- require server-side Authorization header for unified search requests
- sanitize logging to avoid exposing keys

## Testing
- `npm ci --force`
- `npm test` *(fails: 8 failing test files)*
- `deno test supabase/functions/unified-search/index.test.ts` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84d9e764c8324b8109f5a9a840cb3