### PR TITLE
chore: redirect apex domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -112,12 +112,15 @@
   [headers.values]
     Cache-Control = "public, max-age=300, must-revalidate"
 
-# TEMPORARILY DISABLED for troubleshooting redirect loop
-# [[redirects]]
-#   from = "https://maku.travel/*"
-#   to = "https://www.maku.travel/:splat"
-#   status = 301
-#   force = true
+
+# Redirect the apex domain to the canonical www host.
+# Scoped to production so deploy previews and branch deploys
+# don't get caught in a redirect loop.
+[[context.production.redirects]]
+  from = "https://maku.travel/*"
+  to = "https://www.maku.travel/:splat"
+  status = 301
+  force = true
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- redirect apex domain to canonical domain in production

## Testing
- `node -e` script to verify redirect resolves apex domain and preview domain
- `npm test` *(fails: expectAssertion.call is not a function, mocks is not defined)*
- `npm run lint` *(fails: 1708 problems, e.g., no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68b85180875c8324a04faba05aeb5a20