### PR TITLE
Add Deno tests for Amadeus hotel search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
       - name: Install dependencies
         run: npm ci --prefer-offline
         timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run && deno test --allow-env supabase/functions/**/index.test.ts",
     "check:supabase-version": "node scripts/check-supabase-version.mjs"
   },
   "dependencies": {

--- a/supabase/functions/amadeus-hotel-search/index.test.ts
+++ b/supabase/functions/amadeus-hotel-search/index.test.ts
@@ -1,0 +1,71 @@
+import { searchHotels, transformAmadeusHotels } from "./index.ts";
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import { stub, returnsNext } from "https://deno.land/std@0.190.0/testing/mock.ts";
+
+// Mock environment variables to prevent real API calls
+Deno.env.set('SUPABASE_URL', 'https://test.supabase.co');
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-key');
+Deno.env.set('AMADEUS_CLIENT_ID', 'test');
+Deno.env.set('AMADEUS_CLIENT_SECRET', 'test');
+
+function mockFetch() {
+  const hotelListResponse = {
+    data: [
+      { hotelId: 'H1', distance: { value: 1 } }
+    ]
+  };
+
+  const offersResponse = {
+    data: [
+      {
+        hotel: {
+          hotelId: 'H1',
+          name: 'Test Hotel',
+          rating: '4',
+          address: { lines: ['123 Test St'], cityCode: 'ABC' },
+          chainCode: 'CH',
+          distance: { value: 1 }
+        },
+        offers: [
+          {
+            price: { total: 100, currency: 'USD' },
+            policies: { cancellation: { description: 'Free cancel' } }
+          }
+        ]
+      }
+    ]
+  };
+
+  const fetchStub = stub(globalThis, 'fetch', returnsNext([
+    Promise.resolve({ ok: true, json: () => Promise.resolve(hotelListResponse) } as Response),
+    Promise.resolve({ ok: true, json: () => Promise.resolve(offersResponse) } as Response)
+  ]));
+
+  return () => fetchStub.restore();
+}
+
+Deno.test('searchHotels normalizes hotel data', async () => {
+  const restoreFetch = mockFetch();
+
+  const context = {
+    cityCode: 'ABC',
+    checkInDate: '2025-01-01',
+    checkOutDate: '2025-01-02',
+    adults: 2,
+    children: 0,
+    roomQuantity: 1,
+    currency: 'USD'
+  };
+
+  const result = await searchHotels('fake-token', context);
+  const hotels = transformAmadeusHotels(result.data);
+
+  assertEquals(hotels.length, 1);
+  const hotel = hotels[0];
+  assertEquals(hotel.id, 'H1');
+  assertEquals(hotel.name, 'Test Hotel');
+  assertEquals(hotel.pricePerNight, 100);
+  assertEquals(hotel.currency, 'USD');
+
+  restoreFetch();
+});

--- a/supabase/functions/amadeus-hotel-search/index.ts
+++ b/supabase/functions/amadeus-hotel-search/index.ts
@@ -432,3 +432,5 @@ serve(async (req) => {
     );
   }
 });
+
+export { searchHotels, transformAmadeusHotels };


### PR DESCRIPTION
## Summary
- add normalization test for Amadeus hotel search with stubbed API responses
- run Supabase function tests via npm test and GitHub Actions

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` *(fails: 8 files, 7 tests)
- `deno test --allow-env supabase/functions/amadeus-hotel-search/index.test.ts` *(fails: error sending request for url)*

------
https://chatgpt.com/codex/tasks/task_e_68b855d13dd08324bacdda052c00f06b