### PR TITLE
feat: tighten funds and itineraries security policies

### DIFF
--- a/maku-supabase-action/server/bootstrap.sql
+++ b/maku-supabase-action/server/bootstrap.sql
@@ -6,12 +6,29 @@
 drop table if exists funds cascade;
 drop table if exists itineraries cascade;
 
+-- Helper function to automatically set the updated_at column
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+    new.updated_at = timezone('utc', now());
+    return new;
+end;
+$$ language plpgsql;
+
 -- A table to store traveller balances.  Each user_id should be unique.
 create table if not exists funds (
     id uuid default gen_random_uuid() primary key,
-    user_id text not null unique,
-    balance numeric default 0
+    user_id text not null,
+    balance numeric default 0,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
 );
+
+create unique index if not exists funds_user_id_idx on funds (user_id);
+create trigger funds_update_timestamp
+    before update on funds
+    for each row
+    execute procedure update_updated_at();
 
 -- A table to store itineraries for each user.  Each row
 -- corresponds to a booking or trip.  You can extend this schema
@@ -19,14 +36,28 @@ create table if not exists funds (
 create table if not exists itineraries (
     id uuid default gen_random_uuid() primary key,
     user_id text not null,
-    data jsonb not null default '{}'
+    data jsonb not null default '{}',
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
 );
+
+create index if not exists itineraries_user_id_idx on itineraries (user_id);
+create trigger itineraries_update_timestamp
+    before update on itineraries
+    for each row
+    execute procedure update_updated_at();
 
 -- Grant read/write access to the service role.
 alter table funds enable row level security;
 alter table itineraries enable row level security;
 
--- For development purposes these policies are permissive.  In
--- production you should tighten them according to your needs.
-create policy "Allow service role access" on funds for all using (true) with check (true);
-create policy "Allow service role access" on itineraries for all using (true) with check (true);
+-- Policies restrict access to authenticated user rows or service role
+create policy "Allow user or service role access" on funds
+    for all
+    using (auth.uid() = user_id or auth.role() = 'service_role')
+    with check (auth.uid() = user_id or auth.role() = 'service_role');
+
+create policy "Allow user or service role access" on itineraries
+    for all
+    using (auth.uid() = user_id or auth.role() = 'service_role')
+    with check (auth.uid() = user_id or auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- enforce row level security by user or service role
- add created/updated timestamps and indexes to funds and itineraries

## Testing
- `npx supabase db reset --local --no-seed --yes` *(fails: While parsing config: toml: table amadeus-hotel-photos already exists)*
- `npm ci` *(fails: peer dependency conflict with react-day-picker/date-fns)*


------
https://chatgpt.com/codex/tasks/task_e_68b855c7c648832480b78b8c5da69594