### PR TITLE
docs: add rebase conflict resolution checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,6 @@ Run the Vitest suite with:
 ```
 npm test
 ```
+
+## Git workflow tips
+- Keep long-running branches current by following the rebase checklist in [docs/GIT_CONFLICT_RESOLUTION.md](docs/GIT_CONFLICT_RESOLUTION.md).

--- a/docs/GIT_CONFLICT_RESOLUTION.md
+++ b/docs/GIT_CONFLICT_RESOLUTION.md
@@ -1,0 +1,75 @@
+# Resolving Git Merge Conflicts for Maku Travel OTA
+
+This guide documents the exact workflow we use to keep long-running feature branches (such as `emergent-integration`) in sync with `main` while avoiding broken history.
+
+## 1. Update local references
+```bash
+git fetch origin
+```
+Fetching before every rebase guarantees that you are working with the latest commits from both branches.
+
+## 2. Rebase the feature branch onto the base branch
+```bash
+git checkout emergent-integration
+git rebase origin/main
+```
+Rebasing keeps the commit history linear and ensures conflict resolution happens once. If your branch tracks a different base (for example `develop`), substitute that branch name instead of `main`.
+
+> **Tip:** If you prefer to keep a copy of the pre-rebase branch, create a backup before rebasing:
+> ```bash
+> git branch emergent-integration-backup
+> ```
+
+## 3. Resolve conflicts file-by-file
+Git pauses the rebase at each conflicted commit. For every file listed in `git status`:
+
+1. Open the file in your editor.
+2. Remove conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+3. Keep the correct implementation or blend both sides.
+4. Save the file and run project checks (lint/tests) if the file affects runtime behaviour.
+
+When you finish a file, stage it:
+```bash
+git add path/to/file
+```
+
+Once all conflicts in the current commit are staged, continue the rebase:
+```bash
+git rebase --continue
+```
+Repeat until Git reports "Successfully rebased".
+
+If you need to abort at any time and return to the pre-rebase state:
+```bash
+git rebase --abort
+```
+
+## 4. Verify the repository state
+After the rebase completes:
+
+```bash
+git status
+npm run lint
+npm test
+```
+This confirms there are no remaining staged changes and the codebase passes automated checks.
+
+## 5. Force-push with lease protection
+A rebase rewrites commits, so the remote branch must be updated with `--force-with-lease`:
+```bash
+git push origin emergent-integration --force-with-lease
+```
+The `--force-with-lease` flag ensures you only overwrite the remote if no one else has pushed new commits in the meantime.
+
+## 6. Monitor the pull request
+Finally, open the GitHub pull request and confirm:
+
+- The branch reports "This branch has no conflicts".
+- Required status checks (Netlify, Supabase, Vercel, etc.) are green.
+- The PR conversation shows the new commits and no pending review threads.
+
+If any checks fail, address them locally and push additional fixes to the same branch.
+
+---
+
+Keeping this checklist handy should make conflict resolution repeatable and prevent the "Aw, Snap" crashes caused by large PR threads—you can focus on the conflicted files locally and only return to GitHub when the branch is clean.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
- 
- "name": "vite_react_shadcn_ts,
+{
+  "name": "vite_react_shadcn_ts",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- add a dedicated conflict-resolution playbook under docs/GIT_CONFLICT_RESOLUTION.md
- link the checklist from the main README so teammates can find it quickly
- fix the malformed package.json header so npm commands can parse the file again

## Testing
- npm test -- --runInBand *(fails: local environment is missing the vitest binary prior to installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e68fd611108324a804b2342f884ff0