### PR TITLE
feat: add CLI helper to list open pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ Run the Vitest suite with:
 ```
 npm test
 ```
+
+## Git workflow tips
+- Keep long-running branches current by following the rebase checklist in [docs/GIT_CONFLICT_RESOLUTION.md](docs/GIT_CONFLICT_RESOLUTION.md).
+- Check the status of every GitHub pull request from the terminal with `npm run pr:list -- --repo <owner/name>` (requires internet access and an optional `GITHUB_TOKEN` for private repositories).

--- a/docs/GIT_CONFLICT_RESOLUTION.md
+++ b/docs/GIT_CONFLICT_RESOLUTION.md
@@ -1,0 +1,75 @@
+# Resolving Git Merge Conflicts for Maku Travel OTA
+
+This guide documents the exact workflow we use to keep long-running feature branches (such as `emergent-integration`) in sync with `main` while avoiding broken history.
+
+## 1. Update local references
+```bash
+git fetch origin
+```
+Fetching before every rebase guarantees that you are working with the latest commits from both branches.
+
+## 2. Rebase the feature branch onto the base branch
+```bash
+git checkout emergent-integration
+git rebase origin/main
+```
+Rebasing keeps the commit history linear and ensures conflict resolution happens once. If your branch tracks a different base (for example `develop`), substitute that branch name instead of `main`.
+
+> **Tip:** If you prefer to keep a copy of the pre-rebase branch, create a backup before rebasing:
+> ```bash
+> git branch emergent-integration-backup
+> ```
+
+## 3. Resolve conflicts file-by-file
+Git pauses the rebase at each conflicted commit. For every file listed in `git status`:
+
+1. Open the file in your editor.
+2. Remove conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+3. Keep the correct implementation or blend both sides.
+4. Save the file and run project checks (lint/tests) if the file affects runtime behaviour.
+
+When you finish a file, stage it:
+```bash
+git add path/to/file
+```
+
+Once all conflicts in the current commit are staged, continue the rebase:
+```bash
+git rebase --continue
+```
+Repeat until Git reports "Successfully rebased".
+
+If you need to abort at any time and return to the pre-rebase state:
+```bash
+git rebase --abort
+```
+
+## 4. Verify the repository state
+After the rebase completes:
+
+```bash
+git status
+npm run lint
+npm test
+```
+This confirms there are no remaining staged changes and the codebase passes automated checks.
+
+## 5. Force-push with lease protection
+A rebase rewrites commits, so the remote branch must be updated with `--force-with-lease`:
+```bash
+git push origin emergent-integration --force-with-lease
+```
+The `--force-with-lease` flag ensures you only overwrite the remote if no one else has pushed new commits in the meantime.
+
+## 6. Monitor the pull request
+Finally, open the GitHub pull request and confirm:
+
+- The branch reports "This branch has no conflicts".
+- Required status checks (Netlify, Supabase, Vercel, etc.) are green.
+- The PR conversation shows the new commits and no pending review threads. You can also run `npm run pr:list -- --repo <owner/name>` to double-check all open PRs from the terminal (set `GITHUB_TOKEN` if the repository is private).
+
+If any checks fail, address them locally and push additional fixes to the same branch.
+
+---
+
+Keeping this checklist handy should make conflict resolution repeatable and prevent the "Aw, Snap" crashes caused by large PR threads—you can focus on the conflicted files locally and only return to GitHub when the branch is clean.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
- 
- "name": "vite_react_shadcn_ts,
+{
+  "name": "vite_react_shadcn_ts",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run && deno test --allow-env supabase/functions/**/index.test.ts",
-    "check:supabase-version": "node scripts/check-supabase-version.mjs"
+    "check:supabase-version": "node scripts/check-supabase-version.mjs",
+    "pr:list": "node scripts/check-open-prs.mjs"
   },
   "dependencies": {
     "@google/gemini-cli": "^0.4.1",
@@ -82,14 +83,12 @@
     "recharts": "^2.15.4",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
-        "tailwindcss-animate": "^1.0.7",
-
+    "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
     "vaul": "^0.9.9",
     "zod": "^3.25.76",
     "@sentry/react": "^7.89.0",
     "zustand": "^5.0.8"
-          
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/scripts/check-open-prs.mjs
+++ b/scripts/check-open-prs.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { stdout, stderr } from 'node:process';
+
+const args = process.argv.slice(2);
+let repoSlug = null;
+let token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || null;
+let state = 'open';
+let page = 1;
+let perPage = 30;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  switch (arg) {
+    case '--repo':
+    case '-r': {
+      const next = args[i + 1];
+      if (!next) {
+        stderr.write('Error: --repo requires an argument in the form owner/name.\n');
+        process.exit(1);
+      }
+      repoSlug = next;
+      i += 1;
+      break;
+    }
+    case '--token':
+    case '-t': {
+      const next = args[i + 1];
+      if (!next) {
+        stderr.write('Error: --token requires a GitHub personal access token value.\n');
+        process.exit(1);
+      }
+      token = next;
+      i += 1;
+      break;
+    }
+    case '--state': {
+      const next = args[i + 1];
+      if (!next || !['open', 'closed', 'all'].includes(next)) {
+        stderr.write('Error: --state must be one of: open, closed, all.\n');
+        process.exit(1);
+      }
+      state = next;
+      i += 1;
+      break;
+    }
+    case '--per-page': {
+      const next = args[i + 1];
+      const parsed = Number.parseInt(next, 10);
+      if (!next || Number.isNaN(parsed) || parsed < 1 || parsed > 100) {
+        stderr.write('Error: --per-page must be an integer between 1 and 100.\n');
+        process.exit(1);
+      }
+      perPage = parsed;
+      i += 1;
+      break;
+    }
+    case '--page': {
+      const next = args[i + 1];
+      const parsed = Number.parseInt(next, 10);
+      if (!next || Number.isNaN(parsed) || parsed < 1) {
+        stderr.write('Error: --page must be a positive integer.\n');
+        process.exit(1);
+      }
+      page = parsed;
+      i += 1;
+      break;
+    }
+    case '--help':
+    case '-h': {
+      printHelp();
+      process.exit(0);
+    }
+    default: {
+      stderr.write(`Unknown argument: ${arg}\n`);
+      printHelp();
+      process.exit(1);
+    }
+  }
+}
+
+if (!repoSlug) {
+  stderr.write('Error: Missing required --repo argument.\n');
+  printHelp();
+  process.exit(1);
+}
+
+if (!repoSlug.includes('/')) {
+  stderr.write('Error: --repo must be in the form owner/name.\n');
+  process.exit(1);
+}
+
+const headers = {
+  'Accept': 'application/vnd.github+json',
+  'User-Agent': 'maku-travel-verse-pr-checker',
+};
+
+if (token) {
+  headers.Authorization = `Bearer ${token}`;
+}
+
+const endpoint = new URL(`https://api.github.com/repos/${repoSlug}/pulls`);
+endpoint.searchParams.set('state', state);
+endpoint.searchParams.set('per_page', String(perPage));
+endpoint.searchParams.set('page', String(page));
+
+const paginationNotice = (linkHeader) => {
+  if (!linkHeader) return null;
+  const segments = linkHeader.split(',');
+  const rels = new Map();
+  for (const segment of segments) {
+    const match = segment.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (!match) continue;
+    rels.set(match[2], match[1]);
+  }
+  if (rels.has('next')) {
+    return `⚠️ Additional pages available (next: ${rels.get('next')}).`;
+  }
+  return null;
+};
+
+async function main() {
+  try {
+    const response = await fetch(endpoint, { headers });
+    if (response.status === 401) {
+      stderr.write('Error: Unauthorized. Provide a valid GitHub token via --token or GITHUB_TOKEN.\n');
+      process.exit(1);
+    }
+    if (response.status === 404) {
+      stderr.write('Error: Repository not found. Double-check the --repo value.\n');
+      process.exit(1);
+    }
+    if (!response.ok) {
+      const bodyText = await response.text();
+      stderr.write(`GitHub API request failed with status ${response.status}. Body: ${bodyText}\n`);
+      process.exit(1);
+    }
+
+    const pulls = await response.json();
+    if (!Array.isArray(pulls)) {
+      stderr.write('Error: Unexpected response payload from GitHub API.\n');
+      process.exit(1);
+    }
+
+    if (pulls.length === 0) {
+      stdout.write('No pull requests match the specified filters.\n');
+    } else {
+      for (const pr of pulls) {
+        const labels = Array.isArray(pr.labels)
+          ? pr.labels
+              .map((label) => (typeof label === 'object' && label !== null ? label.name : label))
+              .filter(Boolean)
+          : [];
+        const labelStr = labels.length > 0 ? ` [labels: ${labels.join(', ')}]` : '';
+        stdout.write(`#${pr.number} ${pr.title}${labelStr}\n`);
+        stdout.write(`  ${pr.head?.ref ?? 'unknown'} -> ${pr.base?.ref ?? 'unknown'}\n`);
+        stdout.write(`  Updated: ${pr.updated_at}\n`);
+        stdout.write(`  URL: ${pr.html_url}\n`);
+        if (pr.draft) {
+          stdout.write('  Status: Draft\n');
+        }
+        stdout.write('\n');
+      }
+    }
+
+    const notice = paginationNotice(response.headers.get('link'));
+    if (notice) {
+      stdout.write(`${notice}\n`);
+    }
+  } catch (error) {
+    stderr.write(`Unexpected error: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+function printHelp() {
+  stdout.write(`Usage: node scripts/check-open-prs.mjs --repo <owner/name> [options]\n\n`);
+  stdout.write('Options:\n');
+  stdout.write('  --repo, -r <owner/name>   Repository slug (required)\n');
+  stdout.write('  --token, -t <token>       GitHub token (optional, default uses GITHUB_TOKEN env var)\n');
+  stdout.write('  --state <state>           Pull request state filter: open, closed, all (default: open)\n');
+  stdout.write('  --per-page <n>            Results per page (1-100, default: 30)\n');
+  stdout.write('  --page <n>                Page number to retrieve (default: 1)\n');
+  stdout.write('  --help, -h                Show this help message\n');
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a Node-based CLI at scripts/check-open-prs.mjs for listing pull requests via the GitHub API
- wire the helper into package.json as `npm run pr:list` and document its usage in README and the conflict-resolution guide

## Testing
- node scripts/check-open-prs.mjs --help

------
https://chatgpt.com/codex/tasks/task_e_68e68fd611108324a804b2342f884ff0